### PR TITLE
Fix Darwin specific issue with `--parents`

### DIFF
--- a/build_tools/compiler/asset_compiler.rb
+++ b/build_tools/compiler/asset_compiler.rb
@@ -9,10 +9,6 @@ module Compiler
       RbConfig::CONFIG['host_os'] =~ /darwin/
     end
 
-    def on_linux?
-      RbConfig::CONFIG['host_os'] =~ /linux/
-    end
-
     def self.compile
       new.compile
     end
@@ -79,8 +75,11 @@ module Compiler
           files << file
         end
 
-        output, status = Open3.capture2e("cp -r --parents #{files.shelljoin} #{@build_dir.join('views').to_s.shellescape}") if on_linux?
-        output, status = Open3.capture2e("rsync -R #{files.shelljoin} #{@build_dir.join('views').to_s.shellescape}") if on_darwin?
+        if on_darwin?
+          output, status = Open3.capture2e("rsync -R #{files.shelljoin} #{@build_dir.join('views').to_s.shellescape}")
+        else
+          output, status = Open3.capture2e("cp -r --parents #{files.shelljoin} #{@build_dir.join('views').to_s.shellescape}")
+        end
 
         abort "Error copying views:\n#{output}" if status.exitstatus > 0
       end
@@ -97,8 +96,11 @@ module Compiler
           files << file
         end
 
-        output, status = Open3.capture2e("cp -r --parents #{files.shelljoin} #{@build_dir.join('assets').to_s.shellescape}") if on_linux?
-        output, status = Open3.capture2e("rsync -R #{files.shelljoin} #{@build_dir.join('assets').to_s.shellescape}") if on_darwin?
+        if on_darwin?
+          output, status = Open3.capture2e("rsync -R #{files.shelljoin} #{@build_dir.join('assets').to_s.shellescape}")
+        else
+          output, status = Open3.capture2e("cp -r --parents #{files.shelljoin} #{@build_dir.join('assets').to_s.shellescape}")
+        end
         abort "Error copying files:\n#{output}" if status.exitstatus > 0
 
         # Strip leading path component to get logical path as referenced in stylesheets

--- a/build_tools/packager/tar_packager.rb
+++ b/build_tools/packager/tar_packager.rb
@@ -8,10 +8,6 @@ module Packager
       RbConfig::CONFIG['host_os'] =~ /darwin/
     end
 
-    def on_linux?
-      RbConfig::CONFIG['host_os'] =~ /linux/
-    end
-
     def self.build
       new.build
     end
@@ -54,8 +50,11 @@ module Packager
     end
 
     def copy_file(file)
-      output, status = Open3.capture2e("cp --parents #{file.shellescape} #{@target_dir.to_s.shellescape}") if on_linux?
-      output, status = Open3.capture2e("rsync -R #{file.shellescape} #{@target_dir.to_s.shellescape}") if on_darwin?
+      if on_darwin?
+        output, status = Open3.capture2e("rsync -R #{file.shellescape} #{@target_dir.to_s.shellescape}")
+      else
+        output, status = Open3.capture2e("cp --parents #{file.shellescape} #{@target_dir.to_s.shellescape}")
+      end
       abort "Error copying file #{file}:\n#{output}" if status.exitstatus > 0
     end
 


### PR DESCRIPTION
Fix for a Darwin/OSX specific issue for the build rake tasks.

``` bash
bundle exec rake build:tar
Compiling assets and templates into ./app
cp -r --parents layouts/govuk_template.html.erb /Users/petems/Projects/govuk_template/app/views
Error copying views:
cp: illegal option -- -
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file ... target_directory
```

`--parents` isn't a part of the OSX cp library, so the rake task will fail on OSX. Rsync provides the same functionality for Darwin, so changed (this could be changed into `ditto` if needed) :+1:
