### PR TITLE
bumping version number

### DIFF
--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Version number bump seems to have been lost when branch was pulled in from michaeldfallen/govuk_template. Bumping it here.
