### PR TITLE
Play template fixes

### DIFF
--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -6,7 +6,7 @@ module Compiler
     
     def render_erb
       f=File.read(@file) 
-      f.gsub!(/@/, "@@") if !@is_stylesheet 
+      f.gsub!(/@/, "@@") unless @is_stylesheet
       ERB.new(f).result(binding)
     end
     


### PR DESCRIPTION
To use the templates Play requires some changes to the assets paths and to escape the @ character as it is a special character. 

This pull request adds:
- a gsub on the File.read in render_erb which replaces @ with @@ on templates
- implemented assets_path and pointed towards a Play style assets method call
- fixed a few quotes that should have been escaped doubles rather than singles
