### PR TITLE
Keep play build directory in /pkg

### DIFF
--- a/build_tools/packager/play_packager.rb
+++ b/build_tools/packager/play_packager.rb
@@ -10,6 +10,16 @@ module Packager
       @base_name = "play_govuk_template-#{GovukTemplate::VERSION}"
     end
 
+    def build
+      @target_dir = @repo_root.join('pkg', @base_name)
+      @target_dir.rmtree if @target_dir.exist?
+      @target_dir.mkpath
+      Dir.chdir(@target_dir) do |dir|
+        prepare_contents
+        create_tarball
+      end
+    end
+
     def process_template(file)
       target_dir = @target_dir.join(File.dirname(file))
       target_dir.mkpath


### PR DESCRIPTION
This will make publishing the build results to a git repository easier (see #9).
