### PR TITLE
Fix build to behave the same on Linux as on OS X

### DIFF
--- a/build_tools/publisher/play_publisher.rb
+++ b/build_tools/publisher/play_publisher.rb
@@ -13,7 +13,6 @@ module Publisher
     end
 
     def publish
-      puts "Releasing play_govuk_template #{@version} to git repo"
       Dir.mktmpdir("govuk_template_play") do |dir|
         run "git clone -q #{GIT_URL.shellescape} #{dir.shellescape}"
         Dir.chdir(dir) do


### PR DESCRIPTION
This was causing an extra subdirectory to be created when run on Linux
