### PR TITLE
Allow omitting the header from the template

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -61,6 +61,7 @@
 
     <a href="#content" class="visuallyhidden">Skip to main content</a>
 
+    <% unless @omit_header %>
     <header role="banner" id="global-header">
       <div class="header-wrapper">
         <div class="header-global">
@@ -75,6 +76,7 @@
       </div>
     </header>
     <!--end header-->
+    <% end %>
 
     <div id="global-cookie-message">
       <% if content_for?(:cookie_message) %>


### PR DESCRIPTION
This is necessary for the chromeless template in static.
