### PR TITLE
Re-enable task to publish to npmjs.org

### DIFF
--- a/build_tools/publisher/mustache_publisher.rb
+++ b/build_tools/publisher/mustache_publisher.rb
@@ -22,8 +22,7 @@ module Publisher
           run "git commit -q -m 'deploying GOV.UK Mustache templates #{@version}'"
           run "git tag v#{@version}"
           run "git push --tags origin master"
-          # Disabled until the jenkins creds are sorted
-          #run "npm publish ./"
+          run "npm publish ./"
         end
       end
     end


### PR DESCRIPTION
This should be merged after alphagov/ci-puppet#68 has been merged and deployed.
