### PR TITLE
Add after_header hook to template

### DIFF
--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -3,7 +3,7 @@ require_relative 'template_processor'
 
 module Compiler
   class MustacheProcessor < TemplateProcessor
-    
+
     @@yield_hash = {
       page_title: "{{ pageTitle }}",
       head: "{{{ head }}}",
@@ -14,6 +14,7 @@ module Compiler
       footer_top: "{{{ footerTop }}}",
       footer_support_links: "{{{ footerSupportLinks }}}",
       inside_header: "{{{ insideHeader }}}",
+      after_header: "{{{ afterHeader }}}",
       cookie_message: "{{{ cookieMessage }}}"
     }
 

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -3,13 +3,13 @@ require 'compiler/template_processor'
 
 module Compiler
   class PlayProcessor < TemplateProcessor
-    
+
     def render_erb
-      f=File.read(@file) 
+      f=File.read(@file)
       f.gsub!(/@-ms-viewport/, "@@-ms-viewport") unless @is_stylesheet
       ERB.new(f).result(binding)
     end
-    
+
     def handle_yield(section = :layout)
       case section
       when :layout
@@ -28,11 +28,13 @@ module Compiler
         "@bodyEnd"
       when :inside_header
         "@insideHeader"
+      when :after_header
+        "@afterHeader"
       when :footer_top
         "@footerTop"
       when :footer_support_links
         "@footerLinks"
-      else 
+      else
         ""
       end
     end
@@ -50,7 +52,7 @@ module Compiler
     end
 
     def content_for?(*args)
-      [:page_title, :content, :head, :body_classes, :body_end, :top_of_page, :inside_header, :footer_top, :footer_support_links].include? args[0]
+      [:page_title, :content, :head, :body_classes, :body_end, :top_of_page, :inside_header, :after_header, :footer_top, :footer_support_links].include? args[0]
     end
   end
 end

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -82,6 +82,8 @@
     <!--end header-->
     <% end %>
 
+    <%= yield :after_header %>
+
     <div id="global-cookie-message">
       <% if content_for?(:cookie_message) %>
         <%= yield :cookie_message %>


### PR DESCRIPTION
This is so we can add content after the header – ie alpha/beta banners
