### PR TITLE
Fixed footer anchors images showing borders

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -119,6 +119,10 @@ strong {
   font-weight: 600;
 }
 
+img {
+  border: 0;
+}
+
 button {
   *overflow:visible;
 }


### PR DESCRIPTION
Older IE's were showing borders in the footer links.
