### PR TITLE
Add afterHeader parameter

### DIFF
--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -17,7 +17,7 @@ module Compiler
       when :page_title
         "@title.getOrElse(\"GOV.UK - The best place to find government services and information\")"
       when :top_of_page
-        "@(title: Option[String], bodyClasses: Option[String])(head:Html, bodyEnd:Html, insideHeader:Html, footerTop:Html, footerLinks:Html)(content:Html)"
+        "@(title: Option[String], bodyClasses: Option[String])(head:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html)(content:Html)"
       when :head
         "@head"
       when :body_classes


### PR DESCRIPTION
When the `afterHeader` section was added in https://github.com/alphagov/govuk_template/pull/32 this parameter also needed to be added to the top.
