### PR TITLE
Add Mustache inheritance version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ At present this generates 4 output formats:
 1. a gem containing a Rails engine
 2. a tarball containing Play Framework templates
 3. a folder containing Mustache templates
-4. a tarball
+4. a tarball containing Mustache Inheritance templates
+5. a tarball
 
 ### Gem version
 
@@ -40,6 +41,12 @@ To generate the folder of Mustache templates run `bundle exec rake build:mustach
 ### Liquid version
 
 To generate the folder of Liquid templates run `bundle exec rake build:liquid`. This will produce a tarball in the `pkg` directory.
+
+### Mustache Inheritance version
+
+There is a [proposal for Mustache to support template inheritance](https://github.com/mustache/spec/issues/38) this is supported in both the `mustache.java` and the `hogan.js` implementations of Mustache.
+
+To generate the tarball of the Mustache Inheritance templates run the `build:mustache_inheritance` rake task. This will produce a tarball in the `pkg` directory.
 
 ### Tarball version
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :compile do
 end
 
 desc "Build both gem and tar version"
-task :build => ["build:gem", "build:tar", "build:play", "build:mustache", "build:liquid"]
+task :build => ["build:gem", "build:tar", "build:play", "build:mustache", "build:liquid", "build:mustache_inheritance"]
 
 namespace :build do
   desc "Build govuk_template-#{GovukTemplate::VERSION}.gem into the pkg directory"
@@ -47,6 +47,13 @@ namespace :build do
     puts "Building pkg/liquid_govuk_template-#{GovukTemplate::VERSION}"
     require 'packager/liquid_packager'
     Packager::LiquidPackager.build
+  end
+
+  desc "Build mustache_inheritance_govuk_template-#{GovukTemplate::VERSION} into the pkg directory"
+  task :mustache_inheritance => :compile do
+    puts "Building pkg/mustache_inheritance_govuk_template-#{GovukTemplate::VERSION}"
+    require 'packager/mustache_inheritance_packager'
+    Packager::MustacheInheritancePackager.build
   end
 
   desc "Build and release gem to gemfury if version has been updated"

--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -1,0 +1,42 @@
+require 'erb'
+require_relative 'template_processor'
+
+module Compiler
+  class MustacheInheritanceProcessor < TemplateProcessor
+
+    @@yield_hash = {
+      page_title: "{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}",
+      head: "{{$head}}{{/head}}",
+      body_classes: "{{$bodyClasses}}{{/bodyClasses}}",
+      content: "{{$content}}{{/content}}",
+      body_end: "{{$bodyEnd}}{{/bodyEnd}}",
+      footer_top: "{{$footerTop}}{{/footerTop}}",
+      footer_support_links: "{{$footerSupportLinks}}{{/footerSupportLinks}}",
+      inside_header: "{{$insideHeader}}{{/insideHeader}}",
+      after_header: "{{$afterHeader}}{{/afterHeader}}",
+      cookie_message: "{{$cookieMessage}}{{/cookieMessage}}",
+      header_class: "{{$headerClass}}{{/headerClass}}",
+      proposition_header: "{{$propositionHeader}}{{/propositionHeader}}"
+    }
+
+    def handle_yield(section = :layout)
+      @@yield_hash[section]
+    end
+
+    def asset_path(file, options={})
+      return file if @is_stylesheet
+      case File.extname(file)
+      when '.css'
+        "{{assetPath}}stylesheets/#{file}"
+      when '.js'
+        "{{assetPath}}javascripts/#{file}"
+      else
+        "{{assetPath}}images/#{file}"
+      end
+    end
+
+    def content_for?(*args)
+      @@yield_hash.include? args[0]
+    end
+  end
+end

--- a/build_tools/packager/mustache_inheritance_packager.rb
+++ b/build_tools/packager/mustache_inheritance_packager.rb
@@ -1,0 +1,22 @@
+require 'open3'
+require 'govuk_template/version'
+require_relative 'tar_packager'
+require_relative '../compiler/mustache_inheritance_processor'
+
+module Packager
+  class MustacheInheritancePackager < TarPackager
+    def initialize
+      super
+      @base_name = "mustache_inheritance_govuk_template-#{GovukTemplate::VERSION}"
+    end
+
+    def process_template(file)
+      target_dir = @target_dir.join(File.dirname(file))
+      target_dir.mkpath
+      target_file = File.basename(file, File.extname(file)).sub(/\.html\z/, '.mustache')
+      File.open(target_dir.join(target_file), 'wb') do |f|
+        f.write Compiler::MustacheInheritanceProcessor.new(file).process
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is a [proposed extension to Mustache to support template
inheritance](https://github.com/mustache/spec/issues/38). This produces a version of the template which can be
used by implementations which support it.
