### PR TITLE
Add code for propositional navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ The tarball build process takes the compiled template and assets from the `/app`
 
 See the `TemplateProcessor` class for details of this implementation.
 
+## Usage
+
+### Propositional title and navigation
+
+You can get a propositional title and navigation by setting the content for `header_class` to `with-proposition` and `proposition_header` in the form:
+
+    <div class="header-proposition">
+      <div class="content">
+        <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+        <nav id="proposition-menu">
+          <a href="/" id="proposition-name">Service Name</a>
+          <ul id="proposition-links">
+            <li><a href="url-to-page-1" class="active">Navigation item #1</a></li>
+            <li><a href="url-to-page-2">Navigation item #2</a></li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+
+This will then create a navigation block which is shown on desktop sized devices but collapsed down on smaller screens.
+
 ## Contributing
 
 Please follow the [contribution guidelines](https://github.com/alphagov/govuk_template/CONTRIBUTING.md).

--- a/source/assets/javascripts/core.js
+++ b/source/assets/javascripts/core.js
@@ -1,4 +1,6 @@
 (function() {
+  "use strict"
+
   // fix for printing bug in Windows Safari
   var windowsSafari = (window.navigator.userAgent.match(/(\(Windows[\s\w\.]+\))[\/\(\s\w\.\,\)]+(Version\/[\d\.]+)\s(Safari\/[\d\.]+)/) !== null),
       style;
@@ -12,7 +14,34 @@
     document.getElementsByTagName('head')[0].appendChild(style);
   }
 
+
+  // add cookie message
   if (window.GOVUK && GOVUK.addCookieMessage) {
     GOVUK.addCookieMessage();
+  }
+
+  // header navigation toggle
+  if (document.querySelectorAll){
+    var els = document.querySelectorAll('.js-header-toggle'),
+        i, _i;
+    for(i=0,_i=els.length; i<_i; i++){
+      els[i].addEventListener('click', function(e){
+        e.preventDefault();
+        var target = document.getElementById(this.getAttribute('href').substr(1)),
+            targetClass = target.getAttribute('class') || '',
+            sourceClass = this.getAttribute('class') || '';
+
+        if(targetClass.indexOf('js-visible') !== -1){
+          target.setAttribute('class', targetClass.replace(/(^|\s)js-visible(\s|$)/, ''));
+        } else {
+          target.setAttribute('class', targetClass + " js-visible");
+        }
+        if(sourceClass.indexOf('js-hidden') !== -1){
+          this.setAttribute('class', sourceClass.replace(/(^|\s)js-hidden(\s|$)/, ''));
+        } else {
+          this.setAttribute('class', sourceClass + " js-hidden");
+        }
+      });
+    }
   }
 }).call(this);

--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -40,6 +40,30 @@
       }
     }
   }
+  &.with-proposition {
+    .header-wrapper {
+      .header-global {
+        @include media(desktop){
+          float: left;
+          width: 33.33%;
+
+          .header-logo,
+          .site-search {
+            width: 100%;
+          }
+        }
+      }
+      .header-proposition {
+        @include media(desktop){
+          width: 66.66%;
+          float: left;
+        }
+        .content {
+          margin: 0 15px;
+        }
+      }
+    }
+  }
 
   #logo {
     float: left;
@@ -86,6 +110,98 @@
 
     &:active {
       color: $light-blue;
+    }
+  }
+  .header-proposition {
+    padding-top: 10px;
+    @include media(desktop){
+      padding-top: 0;
+    }
+    #proposition-name {
+      @include core-24;
+      font-weight: bold;
+      color: $white;
+      text-decoration: none;
+    }
+    a.menu {
+      @include core-16;
+      color: $white;
+      display: block;
+      float: right;
+      text-decoration: none;
+      padding-top: 6px;
+      @include media(desktop){
+        display: none;
+      }
+      &:hover {
+        text-decoration: underline;
+      }
+      &:after {
+        display: inline-block;
+        font-size: 8px;
+        height: 8px;
+        padding-left: 5px;
+        vertical-align: middle;
+        content: " \25BC";
+      }
+      &.js-hidden:after {
+        content: " \25B2";
+      }
+    }
+    #proposition-menu {
+      margin-top: 5px;
+    }
+    #proposition-links {
+      clear: both;
+      @extend %contain-floats;
+      margin: 2px 0 0 0;
+      padding: 0;
+
+      .js-enabled & {
+        display: none;
+        @include media(desktop){
+          display: block;
+        }
+        &.js-visible {
+          display: block;
+        }
+      }
+
+      li {
+        float: left;
+        width: 50%;
+        padding: 3px 0;
+        border-bottom: 1px solid $grey-2;
+
+        @include media(desktop){
+          display: block;
+          width: auto;
+          padding: 0 15px 0 0;
+          border-bottom: 0;
+
+          &.clear-child {
+            clear: left;
+          }
+        }
+
+        a {
+          color: $white;
+          text-decoration: none;
+          @include bold-14;
+
+          @include media(desktop) {
+            @include bold-16;
+            line-height: 23px;
+          }
+
+          &:hover {
+            text-decoration: underline;
+          }
+          &.active {
+            color: $turquoise;
+          }
+        }
+      }
     }
   }
 }

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -66,7 +66,7 @@
     </div>
 
     <% unless @omit_header %>
-    <header role="banner" id="global-header">
+    <header role="banner" id="global-header" class="<%= yield(:header_class) %>">
       <div class="header-wrapper">
         <div class="header-global">
           <div class="header-logo">
@@ -74,9 +74,9 @@
               <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" alt=""> <span>GOV&nbsp;<span>.</span>UK</span>
             </a>
           </div>
-
           <%= yield :inside_header %>
         </div>
+        <%= yield :proposition_header %>
       </div>
     </header>
     <!--end header-->


### PR DESCRIPTION
For a consistent user experience across services the proposition
navigation should be the consistent. This adds a hook to let the service
define the menu items and also adds the required css to make it look and
work the same as the existing ones on GOV.UK.

This uses querySelectorAll in the JavaScript because all browsers that
will understand the media query to display the mobile nav will
understand querySelectorAll.
