### PR TITLE
Stop header from moving on mouseover in IE7

### DIFF
--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -55,7 +55,8 @@
     font-size: 30px;
     line-height: 1em;
     text-decoration: none;
-    margin-bottom: 1px;
+    margin-bottom: -1px;
+    padding-bottom: 1px;
 
     img {
       position: relative;
@@ -80,7 +81,7 @@
     &:focus {
       text-decoration: none;
       border-bottom: 1px solid;
-      margin-bottom: 0;
+      padding-bottom: 0;
     }
 
     &:active {


### PR DESCRIPTION
Due to a bug in the way IE applies margins on hover the header grows and
shrinks a pixel on hover. This swaps out the margin for a padding which
fixes the moving. It also adds a negative margin to the bottom of the
logo to bring it back to the same height as the search box. Otherwise
the spacing looks strange.

This was discovered when looking at the possibility of merging: https://github.com/alphagov/static/pull/342
