### PR TITLE
simplify kerning technique

### DIFF
--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -79,26 +79,23 @@
     font-size: 30px;
     line-height: 1em;
     text-decoration: none;
+    text-rendering: optimizeLegibility;
     margin-bottom: -1px;
     padding-bottom: 1px;
 
     img {
       position: relative;
-      top: -3px;
+      top: -2px;
 
       width: 35px;
       height: 31px;
 
-      padding-right: 8px;
+      padding-right: 6px;
 
       float: left;
       display: inline;
       line-height: inherit;
       border: none;
-    }
-
-    span>span {
-      margin: 0 1px 0 -6px;
     }
 
     &:hover,

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -71,7 +71,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-              <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" alt=""> <span>GOV&nbsp;<span>.</span>UK</span>
+              <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" alt=""> GOV.UK
             </a>
           </div>
           <%= yield :inside_header %>


### PR DESCRIPTION
- remove span elements with negative margins
- add text-rendering: optimizeLegibility; css rule to activate the
  kerning pairs already built into the webfont
