### PR TITLE
Decapitalisation of copyright in 'Crown copyright'

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -110,7 +110,7 @@
           </div>
 
           <div class="copyright">
-            <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown Copyright</a>
+            <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Both the National Archives (http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm) and the Copyright, Designs and Patents Act 1988 (http://www.legislation.gov.uk/ukpga/1988/48/section/163) refer to Crown copyright, not Crown Copyright.
