### PR TITLE
Use a template file for title for flexibility

### DIFF
--- a/build_tools/compiler/liquid_processor.rb
+++ b/build_tools/compiler/liquid_processor.rb
@@ -15,7 +15,7 @@ module Compiler
       head: "{% include layouts/_head.html %}",
       header_class: "{% if page.header_class %}{{ page.header_class }}{% endif %}",
       inside_header: "{% include layouts/_inside_header.html %}",
-      page_title: "{% if page.title %}{{ page.title }}{% endif %}",
+      page_title: "{% include layouts/_page_title.html %}",
       proposition_header: "{% include layouts/_proposition_header.html %}"
     }
 


### PR DESCRIPTION
Different projects are going to have different requirements on how the
heading is set. Lots of them are going to want to specify a custom
suffix. This lets them do it.
