### PR TITLE
Check for addEventListener

### DIFF
--- a/source/assets/javascripts/core.js
+++ b/source/assets/javascripts/core.js
@@ -21,7 +21,7 @@
   }
 
   // header navigation toggle
-  if (document.querySelectorAll){
+  if (document.querySelectorAll && document.addEventListener){
     var els = document.querySelectorAll('.js-header-toggle'),
         i, _i;
     for(i=0,_i=els.length; i<_i; i++){


### PR DESCRIPTION
IE8 understands querySelectorAll but not addEventListener.

This block of javascript is needed for browsers the understand media
queries. As IE8 doesn't support media queries it doesn't need to run
this code so check for addEventListner also.

This fixes a JavaScript error users are currently seeing in IE8.
