### PR TITLE
Fix for JavaScript bug in IE8

### DIFF
--- a/source/assets/javascripts/core.js
+++ b/source/assets/javascripts/core.js
@@ -21,7 +21,7 @@
   }
 
   // header navigation toggle
-  if (document.querySelectorAll){
+  if (document.querySelectorAll && document.addEventListener){
     var els = document.querySelectorAll('.js-header-toggle'),
         i, _i;
     for(i=0,_i=els.length; i<_i; i++){


### PR DESCRIPTION
The code currently uses a test for `document.querySelectorAll` to determine if the block after will run. 
The block contains use of `element.addEventListener` which is causing an error in IE8 as IE8 supports `document.querySelectorAll` but not `element.addEventListener`.

https://developer.mozilla.org/en-US/docs/Web/API/Document.querySelectorAll
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.addEventListener#Browser_compatibility
