### PR TITLE
Remove extra bespoke colours

### DIFF
--- a/source/assets/stylesheets/styleguide/_colours.scss
+++ b/source/assets/stylesheets/styleguide/_colours.scss
@@ -1,4 +1,4 @@
-/* New Greys */
+/* Old depricated greys, new things should use the toolkit greys */
 $grey-0: #0b0c0c;
 $grey-1: #171819;
 $grey-2: #2e3133;
@@ -9,14 +9,3 @@ $grey-6: #a1acb2;
 $grey-7: #b8c6cc;
 $grey-8: #DEE0E2;
 $grey-9: #eaedef;
-
-// Semantic colour names
-$text-colour: $grey-0;
-$link-colour: #2e3191;
-$link-active-colour: #2e8aca;
-$link-hover-colour: #2e8aca;
-$link-visited-colour: #2e3191;
-
-// Pure greys
-$black: $grey-0;
-$true-black: #000; // you should have a really good reason for using this


### PR DESCRIPTION
The link colours are defined in the toolkit. They should be used
everywhere.

The black and true black variables are duplicates of things in the
toolkit.

The 'new greys' are now depricated in favour of the ones in the toolkit.
