### PR TITLE
Add explicit width and height to crown logo.

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -71,7 +71,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-              <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" alt=""> GOV.UK
+              <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" width="35" height="31" alt=""> GOV.UK
             </a>
           </div>
           <%= yield :inside_header %>


### PR DESCRIPTION
PageSpeed suggests this ought to be a (minor) performance improvement. 

We never seem to resize this image anywhere, so it might as well have an
explicit width and height.
