### PR TITLE
Remove width: 49% from GOV.UK logo

### DIFF
--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -20,7 +20,6 @@
       @extend %contain-floats;
       .header-logo {
         @extend %contain-floats;
-        width: 49%;
         float: left;
 
         @include media(desktop){


### PR DESCRIPTION
At certain viewport widths the GOV.UK logo drops below the crown logo. Tablets and/or phones happen to exist which are the correct width to make this bug appear.

Removing this one line fixes that bug and as far as I can tell does not introduce any other bugs.
