### PR TITLE
Remove specific font-size for OGL link in footer

### DIFF
--- a/source/assets/stylesheets/_footer.scss
+++ b/source/assets/stylesheets/_footer.scss
@@ -127,14 +127,6 @@
           @include core-16;
           margin: 0;
           padding-top: 0.1em;
-
-          a {
-            @include core-14;
-
-            @include media-down(mobile) {
-              font-size: 1em;
-            }
-          }
         }
       }
     


### PR DESCRIPTION
This looks like it's been set intentionally, but in the browser this means that the link text is ever so slightly smaller than the paragraph around it, which looks weird:

![screen shot 2014-03-21 at 08 40 53](https://f.cloud.github.com/assets/121219/2481192/89761fa8-b0d4-11e3-99a7-947abcd11eb5.png)
