### PR TITLE
Move cookie message above header

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -65,6 +65,19 @@
       </div>
     </div>
 
+    <div id="global-cookie-message">
+      <div class="outer-block">
+        <div class="inner-block">
+          <% if content_for?(:cookie_message) %>
+            <%= yield :cookie_message %>
+          <% else %>
+            <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <!--end global-cookie-message-->
+
     <% unless @omit_header %>
     <header role="banner" id="global-header" class="<%= yield(:header_class) %>">
       <div class="header-wrapper">
@@ -83,19 +96,6 @@
     <% end %>
 
     <%= yield :after_header %>
-
-    <div id="global-cookie-message">
-      <div class="outer-block">
-        <div class="inner-block">
-          <% if content_for?(:cookie_message) %>
-            <%= yield :cookie_message %>
-          <% else %>
-            <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
-          <% end %>
-        </div>
-      </div>
-    </div>
-    <!--end global-cookie-message-->
 
     <div id="global-header-bar">
       <div class="inner-block">


### PR DESCRIPTION
This prevents the situation where the cookie message, new phase banner and
survey compete for attention under the header. 

The cookie message appears once at the top, moving the content beneath it down.

Screenshots:

![gov uk - cookie message - mobile](https://cloud.githubusercontent.com/assets/417754/2956546/b9893248-da91-11e3-86f4-6c223037c78f.png)

![gov uk - cookie message - desktop](https://cloud.githubusercontent.com/assets/417754/2956548/be0b8eec-da91-11e3-9894-41d57030b9af.png)
