### PR TITLE
Don't HTML-escape the assetPath with Mustache

### DIFF
--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -28,11 +28,11 @@ module Compiler
       return file if @is_stylesheet
       case File.extname(file)
       when '.css'
-        "{{assetPath}}stylesheets/#{file}"
+        "{{{ assetPath }}}stylesheets/#{file}"
       when '.js'
-        "{{assetPath}}javascripts/#{file}"
+        "{{{ assetPath }}}javascripts/#{file}"
       else
-        "{{assetPath}}images/#{file}"
+        "{{{ assetPath }}}images/#{file}"
       end
     end
 

--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -30,11 +30,11 @@ module Compiler
       return "#{file}?#{query_string}" if @is_stylesheet
       case File.extname(file)
       when '.css'
-        "{{ assetPath }}stylesheets/#{file}?#{query_string}"
+        "{{{ assetPath }}}stylesheets/#{file}?#{query_string}"
       when '.js'
-        "{{ assetPath }}javascripts/#{file}?#{query_string}"
+        "{{{ assetPath }}}javascripts/#{file}?#{query_string}"
       else
-        "{{ assetPath }}images/#{file}?#{query_string}"
+        "{{{ assetPath }}}images/#{file}?#{query_string}"
       end
     end
 

--- a/spec/build_tools/compiler/mustache_processor_spec.rb
+++ b/spec/build_tools/compiler/mustache_processor_spec.rb
@@ -62,20 +62,20 @@ describe Compiler::MustacheProcessor do
       context "if css file path passed in" do
         let(:css_asset_file) {"a/file.css"}
         it "should return the correct path for a stylesheet" do
-          subject.asset_path(css_asset_file).should == "{{ assetPath }}stylesheets/#{css_asset_file}?#{GovukTemplate::VERSION}"
+          subject.asset_path(css_asset_file).should == "{{{ assetPath }}}stylesheets/#{css_asset_file}?#{GovukTemplate::VERSION}"
         end
       end
       context "if javascript file path passed in" do
         let(:js_asset_file) {"a/file.js"}
         #up for debate - whole project is js
         it "should return the correct path for a javascript file" do
-          subject.asset_path(js_asset_file).should == "{{ assetPath }}javascripts/#{js_asset_file}?#{GovukTemplate::VERSION}"
+          subject.asset_path(js_asset_file).should == "{{{ assetPath }}}javascripts/#{js_asset_file}?#{GovukTemplate::VERSION}"
         end
       end
       context "if other file path passed in" do
         let(:other_asset_file) {"a/file.png"}
         it "should return the correct path for an image" do
-          subject.asset_path(other_asset_file).should == "{{ assetPath }}images/#{other_asset_file}?#{GovukTemplate::VERSION}"
+          subject.asset_path(other_asset_file).should == "{{{ assetPath }}}images/#{other_asset_file}?#{GovukTemplate::VERSION}"
         end
       end
     end

--- a/spec/build_tools/packager/mustache_packager_spec.rb
+++ b/spec/build_tools/packager/mustache_packager_spec.rb
@@ -21,7 +21,7 @@ describe Packager::MustachePackager do
 
         generated_template = File.read(generated_template_path)
         generated_template.should =~ %r[\A{{{ topOfPage }}}]
-        generated_template.should =~ %r[href="{{ assetPath }}stylesheets/govuk-template\.css\?#{Regexp.escape(GovukTemplate::VERSION)}"]
+        generated_template.should =~ %r[href="{{{ assetPath }}}stylesheets/govuk-template\.css\?#{Regexp.escape(GovukTemplate::VERSION)}"]
 
         File.read(generated_package_json_path).should == example_package_json
       end


### PR DESCRIPTION
Use Mustache's 3 curly braces to indicate that we don't want the assetPath variable to be HTML escaped.

The assetPath is referenced from inside the href attribute of link tags, and is generally formed of either a path or a URL containing a hostname.

Currently, the template outputs HTML like this:

```
<link href="https:&#x2F;&#x2F;foo.service.gov.uk&#x2F;css&#x2F;stylesheets/govuk-template.css" />
```

This commit changes it to something more like this:

```
<link href="https://foo.service.gov.uk/css/stylesheets/govuk-template.css" />
```

(See also alphagov/spotlight#497 for more context. I think we're seeing requests from badly behaved clients that don't interpret HTML escaped values inside `href`s correctly. Most clients seem to work fine.)
