### PR TITLE
Fix invalid asterisk selector hack

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -126,8 +126,10 @@ img {
   border: 0;
 }
 
-button {
-  *overflow:visible;
+@include ie-lte(7) {
+  button {
+    overflow:visible;
+  }
 }
 
 abbr[title] {


### PR DESCRIPTION
We already have logical constructs for targeting specific versions of IE, so we can use those for IE7 instead of the asterisk hack.
