### PR TITLE
Bump govuk_frontend_toolkit to latest version

### DIFF
--- a/govuk_template.gemspec
+++ b/govuk_template.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'sprockets', '2.10.0'
   spec.add_development_dependency 'sass', '3.2.9'
-  spec.add_development_dependency 'govuk_frontend_toolkit', '0.48.0'
+  spec.add_development_dependency 'govuk_frontend_toolkit', '1.6.1'
   spec.add_development_dependency 'gem_publisher', '1.3.0'
   spec.add_development_dependency 'rspec', '2.14.1'
 end


### PR DESCRIPTION
The only change which this effects is it gets a new visited link colour.

The full diff of changes can be seen here: 
https://github.com/alphagov/govuk_frontend_toolkit/compare/43b63ce8bcf0b4f8a7fd0e86af451e3883c10f23...8ea444acc65244589b9ede259493551798434a51
