### PR TITLE
Set html background to match footer background colour

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -39,6 +39,7 @@ html, body, div, h1, h2, h3, h4, h5, h6, article, aside, footer, header, hgroup,
 html {
   -webkit-text-size-adjust: 100%; /* 1 */
   -ms-text-size-adjust: 100%; /* 1 */
+  // Set background colour to match footer background
   background-color: $grey-8;
 }
 


### PR DESCRIPTION
For pages with short content the footer doesn't sit at the bottom of the page. 
Setting a background colour which matches the footer background colour fixes this.
