### PR TITLE
Add HTML5 display definition

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -7,6 +7,11 @@ html, body, div, h1, h2, h3, h4, h5, h6, article, aside, footer, header, hgroup,
   vertical-align: baseline;
 }
 
+// HTML5 display definition
+main {
+  display: block;
+}
+
 // self clearing floats
 .group:before,
 .group:after {


### PR DESCRIPTION
- Correct `block` display not defined for any HTML5 element in IE 8/9.
- Correct `block` display not defined for `main` in IE 11

This has repeatedly tripped people up (myself included), so I'd like to suggest adding it to the template to ensure the new grids in the frontend toolkit work as expected cross-browser.
