### PR TITLE
moved the js-enabled class to the html element. This counters FOUC.

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -1,6 +1,6 @@
 <%= yield :top_of_page %>
 <!DOCTYPE html>
-<!--[if lt IE 9]><html class="lte-ie8 js-disabled" lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>"><![endif]-->
+<!--[if lt IE 9]><html class="lte-ie8 no-js" lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>"><![endif]-->
 <!--[if gt IE 8]><!--><html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>" class="no-js"><!--<![endif]-->
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
I've moved the js-enabled class to the html tag for a few reasons.
- Stops FOUC by being enabled before the CSS is loaded. `html` is a more natural fit then `body` tag in this case.
- `js-disabled` class by default for css hook. In similar vain to `js-enabled`.
