### PR TITLE
Add font smoothing for Firefox

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -54,6 +54,7 @@ body {
   line-height: 1.5;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 ol, ul, nav ol, nav ul {


### PR DESCRIPTION
When viewing pages in Firefox OSX, the fonts appear heavier than
specified.

Using -moz-osx-font-smoothing: grayscale; fixes this.

[Here's the history of this on Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=857142).
