### PR TITLE
Move doc publishing into gem publishing step

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,6 +73,12 @@ namespace :build do
       p.pusher.push "pkg/govuk_template-#{GovukTemplate::VERSION}.gem", :rubygems
       p.git_remote.add_tag "v#{GovukTemplate::VERSION}"
       puts "Done."
+
+      require 'publisher/docs_publisher'
+      q = Publisher::DocsPublisher.new
+      puts "Pushing docs #{GovukTemplate::VERSION} to git repo"
+      q.publish
+      puts "Done."
     end
 
     require 'publisher/release_publisher'
@@ -99,15 +105,6 @@ namespace :build do
       puts "govuk_template_mustache #{GovukTemplate::VERSION} already released. Not pushing."
     else
       puts "Pushing govuk_template_mustache #{GovukTemplate::VERSION} to git repo"
-      q.publish
-    end
-
-    require 'publisher/docs_publisher'
-    q = Publisher::DocsPublisher.new
-    if q.version_released?
-      puts "docs #{GovukTemplate::VERSION} already released. Not pushing."
-    else
-      puts "Pushing docs #{GovukTemplate::VERSION} to git repo"
       q.publish
     end
   end

--- a/build_tools/publisher/docs_publisher.rb
+++ b/build_tools/publisher/docs_publisher.rb
@@ -50,11 +50,6 @@ module Publisher
       end
     end
 
-    def version_released?
-      output = run("git ls-remote --tags #{GIT_URL.shellescape}")
-      return !! output.match(/v#{@version}/)
-    end
-
     private
 
     def run(command)


### PR DESCRIPTION
The doc publishing was checking the repo for a tag which would have been
added by the gem publisher earlier in the rake task. This moves the docs
publishing next to the gem publishing which will handle making sure we
only publish new docs on version bumping.
