### PR TITLE
Force scrollbar to always display on IE10/11

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -48,6 +48,13 @@ html {
   background-color: $grey-8;
 }
 
+/*
+  Force the scrollbar to always display in IE10/11
+ */
+html {
+  -ms-overflow-style: scrollbar;
+}
+
 body {
   background: $white;
   color: $text-colour;


### PR DESCRIPTION
Scrollbar behaviour consistent with BBC, Guardian, Amazon etc. 

Linked to ticket: https://www.agileplannerapp.com/boards/105200/cards/5215

More context is provided on requesters in the Zendesk tickets:
- https://govuk.zendesk.com/agent/#/tickets/779283
- https://govuk.zendesk.com/agent/#/tickets/827154
