### PR TITLE
Allow content immediately after opening body tag

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -59,6 +59,8 @@
   <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>
     <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
+    <%= yield :body_start %>
+
     <div id="skiplink-container">
       <div>
         <a href="#content" class="skiplink">Skip to main content</a>


### PR DESCRIPTION
Yields content for `:body_start` immediately after the opening `<body>` tag.

In this instance this is to allow Google Tag Manager code to be inserted as per their developer instructions.
