### PR TITLE
Self-close link/meta/img tags

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -42,16 +42,16 @@
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
 
     <!-- Size for iPad and iPad mini (high resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="<%= asset_path "apple-touch-icon-152x152.png" %>">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="<%= asset_path "apple-touch-icon-152x152.png" %>" />
     <!-- Size for iPhone and iPod touch (high resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="<%= asset_path "apple-touch-icon-120x120.png" %>">
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="<%= asset_path "apple-touch-icon-120x120.png" %>" />
     <!-- Size for iPad 2 and iPad mini (standard resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="<%= asset_path "apple-touch-icon-76x76.png" %>">
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="<%= asset_path "apple-touch-icon-76x76.png" %>" />
     <!-- Default non-defined size, also used for Android 2.1+ devices -->
-    <link rel="apple-touch-icon-precomposed" href="<%= asset_path "apple-touch-icon-60x60.png" %>">
+    <link rel="apple-touch-icon-precomposed" href="<%= asset_path "apple-touch-icon-60x60.png" %>" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>" />
 
     <%= yield :head %>
   </head>
@@ -84,7 +84,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-              <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" width="35" height="31" alt=""> GOV.UK
+              <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" width="35" height="31" alt="" /> GOV.UK
             </a>
           </div>
           <%= yield :inside_header %>


### PR DESCRIPTION
- Self-close all link/meta/img tags for consistency. Some link tags were already self-closed.
- Understand this is not strictly necessary, but it is friendly to XML editor tools which some of us use.
