### PR TITLE
Support for single item proposition menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ You can get a propositional title and navigation by setting the content for `hea
 
 This will then create a navigation block which is shown on desktop sized devices but collapsed down on smaller screens.
 
+For menus with only one item, the collapsible functionality is not necessary, it is recommended that you use the following markup
+
+    <div class='header-proposition'>
+      <div class='content'>
+        <nav id='proposition-menu'>
+          <a href='/' id='proposition-name'>Service Name</a>
+          <p id='proposition-link'>
+            <a href='url-to-page-1'>Navigation item #1</a>
+          </p>
+        </nav>
+      </div>
+    </div>
+
 ## Contributing
 
 Please follow the [contribution guidelines](https://github.com/alphagov/govuk_template/blob/master/CONTRIBUTING.md).

--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -163,6 +163,7 @@
         }
       }
     }
+    #proposition-link,
     #proposition-links {
       clear: both;
       @extend %contain-floats;
@@ -195,27 +196,38 @@
             clear: left;
           }
         }
+      }
 
-        a {
-          color: $white;
-          text-decoration: none;
-          @include bold-14;
+      a {
+        color: $white;
+        text-decoration: none;
+        @include bold-14;
 
-          @include media(desktop) {
-            @include bold-16;
-            line-height: 23px;
-          }
-
-          &:hover {
-            text-decoration: underline;
-          }
-          &.active {
-            color: $proposition-active-nav;
-          }
-          &:focus {
-            color: $black;
-          }
+        @include media(desktop) {
+          @include bold-16;
+          line-height: 23px;
         }
+
+        &:hover {
+          text-decoration: underline;
+        }
+        &.active {
+          color: $proposition-active-nav;
+        }
+        &:focus {
+          color: $black;
+        }
+      }
+    }
+
+    #proposition-link {
+      float: right;
+      line-height: 22px;
+      .js-enabled & {
+        display:block;
+      }
+      @include media(desktop) {
+        float:none;
       }
     }
   }


### PR DESCRIPTION
Collapsible menu behavour isn't appropriate for single item menus.
Display the single item in place of the 'menu' link.
This resolves #121 
