### PR TITLE
Support for single item proposition menu

### DIFF
--- a/data/example-proposition-link.yml
+++ b/data/example-proposition-link.yml
@@ -1,0 +1,13 @@
+assetPath: "/govuk_template//assets/"
+headerClass: "with-proposition"
+propositionHeader: >
+  <div class='header-proposition'>
+    <div class='content'>
+      <nav id='proposition-menu'>
+        <a href='/govuk_template/' id='proposition-name'>Service Name</a>
+        <p id='proposition-link'>
+          <a href='url-to-page-1' class='active'>Navigation item #1</a>
+        </p>
+      </nav>
+    </div>
+  </div>

--- a/data/index.yml
+++ b/data/index.yml
@@ -28,6 +28,10 @@ content: >
         <strong><a href='/govuk_template/example-proposition-menu.html'>GOV.UK standard header – with propositional navigation</a></strong><br>
         If you need to include basic navigation, contact or account management links.
       </li>
+      <li>
+        <strong><a href='/govuk_template/example-proposition-link.html'>GOV.UK standard header – with propositional link</a></strong><br>
+        If you need to include a single navigation link.
+      </li>
     </ul>
 
     <h2>Downloads</h2>


### PR DESCRIPTION
Collapsible menu behavour isn't appropriate for single item menus.
Display the single item in place of the 'menu' link.
