### PR TITLE
Add body_start to template compilers

### DIFF
--- a/build_tools/compiler/ejs_processor.rb
+++ b/build_tools/compiler/ejs_processor.rb
@@ -7,6 +7,7 @@ module Compiler
     @@yield_hash = {
       after_header: "<%- partial('partials/_after_header') %>",
       body_classes: "<%= bodyClasses %>",
+      body_start: "<%- partial('partials/_body_start') %>",
       body_end: "<%- partial('partials/_body_end') %>",
       content: "<%- partial('partials/_content') %>",
       cookie_message: "<%- partial('partials/_cookie_message') %>",

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -7,6 +7,7 @@ module Compiler
     @@yield_hash = {
       after_header: "{% block after_header %}{% endblock %}",
       body_classes: "{% block body_classes %}{% endblock %}",
+      body_start: "{% block body_start %}{% endblock %}",
       body_end: "{% block body_end %}{% endblock %}",
       content: "{% block content %}{% endblock %}",
       cookie_message: "{% block cookie_message %}{% endblock %}",

--- a/build_tools/compiler/liquid_processor.rb
+++ b/build_tools/compiler/liquid_processor.rb
@@ -7,6 +7,7 @@ module Compiler
     @@yield_hash = {
       after_header: "{% include layouts/_after_header.html %}",
       body_classes: "{% include layouts/_body_classes.html %}",
+      body_start: "{% include layouts/_body_start.html %}",
       body_end: "{% include layouts/_body.html %}",
       content: "{{ content }}",
       cookie_message: "{% include layouts/_cookie_message.html %}",

--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -7,6 +7,7 @@ module Compiler
     @@yield_hash = {
       after_header: "{{$afterHeader}}{{/afterHeader}}",
       body_classes: "{{$bodyClasses}}{{/bodyClasses}}",
+      body_start: "{{$bodyStart}}{{/bodyStart}}",
       body_end: "{{$bodyEnd}}{{/bodyEnd}}",
       content: "{{$content}}{{/content}}",
       cookie_message: "{{$cookieMessage}}{{/cookieMessage}}",

--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -7,6 +7,7 @@ module Compiler
     @@yield_hash = {
       after_header: "{{{ afterHeader }}}",
       body_classes: "{{ bodyClasses }}",
+      body_start: "{{{ bodyStart }}}",
       body_end: "{{{ bodyEnd }}}",
       content: "{{{ content }}}",
       cookie_message: "{{{ cookieMessage }}}",

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -19,7 +19,7 @@ module Compiler
       when :page_title
         "@title.getOrElse(\"GOV.UK - The best place to find government services and information\")"
       when :top_of_page
-        "@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = Html.empty, propositionHeader:Html = Html.empty)(content:Html)"
+        "@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = Html.empty, propositionHeader:Html = Html.empty)(content:Html)"
       when :head
         "@head"
       when :body_classes
@@ -30,6 +30,8 @@ module Compiler
         "@propositionHeader"
       when :content
         "@content"
+      when :body_start
+        "@bodyStart"
       when :body_end
         "@bodyEnd"
       when :inside_header
@@ -58,7 +60,7 @@ module Compiler
     end
 
     def content_for?(*args)
-      [:layout, :page_title, :content, :head, :body_classes, :body_end,
+      [:layout, :page_title, :content, :head, :body_classes, :body_start, :body_end,
         :top_of_page, :inside_header, :after_header, :footer_top,
         :footer_support_links, :html_lang, :header_class, :propositional_header
       ].include? args[0]


### PR DESCRIPTION
A block for body_start was added to the source template in https://github.com/alphagov/govuk_template/pull/119. Add
corresponding sections to each of the compilers so all templates can use
the body_start block.
