### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.12.0
+
+- Add: `body_start` to enable html to be placed at the first element of the body
+- Add: option to have a single navigation link rather than a full menu
+
 # 0.11.0
 
 - Add support for Embedded JavaScript templates

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
- Add: `body_start` to enable html to be placed at the first element of
  the body
- Add: option to have a single navigation link rather than a full menu

Commits for this version: https://github.com/alphagov/govuk_template/compare/60197b5...8c00a25
