### PR TITLE
Update readme with skip link usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ See the `TemplateProcessor` class for details of this implementation.
 
 ## Usage
 
+### Skip link
+
+The [govuk_template sets a skip link](https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb#L64-L68) to `#content`, but doesn't provide an element with `id="content"`. You'll need to add `id="content"` to your main content area, to ensure the skip link will work.
+
 ### Propositional title and navigation
 
 You can get a propositional title and navigation by setting the content for `header_class` to `with-proposition` and `proposition_header` in the form:


### PR DESCRIPTION
The template sets a skip link to `#content`. In order for this to work
`id=“content”` must be set on the main content area.

Adding @edds's reply to the Digital Service Designers mailing list to the readme.