### PR TITLE
Remove inline JavaScript

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task :compile do
   Compiler::AssetCompiler.compile
 end
 
-desc "Build both gem and tar version"
+desc "Build all versions"
 task :build => ["build:gem", "build:tar", "build:play", "build:mustache", "build:liquid", "build:mustache_inheritance", "build:jinja", "build:ejs"]
 
 namespace :build do

--- a/lib/govuk_template/engine.rb
+++ b/lib/govuk_template/engine.rb
@@ -5,7 +5,10 @@ module GovukTemplate
         govuk-template*.css
         fonts*.css
         govuk-template.js
+        ie-8.js
+        ie-mobile-10.js
         ie.js
+        js-enabled.js
         vendor/goog/webfont-debug.js
       )
     end

--- a/manifests.yml
+++ b/manifests.yml
@@ -10,5 +10,8 @@ stylesheets:
 - fonts-ie8
 javascripts:
 - govuk-template
+- ie-8
+- ie-mobile-10
 - ie
+- js-enabled
 - vendor/goog/webfont-debug.js

--- a/source/assets/javascripts/ie-8.js
+++ b/source/assets/javascripts/ie-8.js
@@ -1,0 +1,26 @@
+(function() {
+  if (window.opera) {
+    return;
+  }
+
+  setTimeout(function() {
+    var a = document,
+        g, b = {
+          families: (g=["nta"]),
+          urls: ["<%= asset_path "fonts-ie8.css" %>"]
+        },
+        c = "<%= asset_path "vendor/goog/webfont-debug.js" %>",
+        d = "script",
+        e = a.createElement(d),
+        f = a.getElementsByTagName(d)[0],
+        h = g.length;
+
+    WebFontConfig = {
+      custom: b
+    },
+    e.src = c,
+    f.parentNode.insertBefore(e,f);
+    for (; h = h-1; a.documentElement.className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');
+  }, 0)
+
+})()

--- a/source/assets/javascripts/ie-mobile-10.js
+++ b/source/assets/javascripts/ie-mobile-10.js
@@ -1,0 +1,9 @@
+(function() {
+  if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
+    var d = document,
+        c = "appendChild",
+        a = d.createElement("style");
+    a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));
+    d.getElementsByTagName("head")[0][c](a);
+  }
+})();

--- a/source/assets/javascripts/js-enabled.js
+++ b/source/assets/javascripts/js-enabled.js
@@ -1,0 +1,1 @@
+document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -7,9 +7,7 @@
 
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
-    <script type="text/javascript">
-      (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
-    </script>
+    <script src="<%= asset_path "ie-mobile-10.js" %>" type="text/javascript"></script>
 
     <!--[if gt IE 8]><!--><link href="<%= asset_path "govuk-template.css" %>" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
     <!--[if IE 6]><link href="<%= asset_path "govuk-template-ie6.css" %>" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
@@ -19,16 +17,7 @@
     <link href="<%= asset_path "govuk-template-print.css" %>" media="print" rel="stylesheet" type="text/css" />
 
     <!--[if IE 8]>
-    <script type="text/javascript">
-      (function(){if(window.opera){return;}
-       setTimeout(function(){var a=document,g,b={families:(g=
-       ["nta"]),urls:["<%= asset_path "fonts-ie8.css" %>"]},
-       c="<%= asset_path "vendor/goog/webfont-debug.js" %>",d="script",
-       e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
-       ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
-       .className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');},0)
-      })()
-    </script>
+      <script src="<%= asset_path "ie-8.js" %>" type="text/javascript"></script>
     <![endif]-->
     <!--[if gte IE 9]><!-->
       <link href="<%= asset_path "fonts.css" %>" media="all" rel="stylesheet" type="text/css" />
@@ -57,7 +46,7 @@
   </head>
 
   <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>
-    <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script src="<%= asset_path "js-enabled.js" %>" type="text/javascript"></script>
 
     <%= yield :body_start %>
 


### PR DESCRIPTION
**Please don't merge this pull request in its current state. It's open for feedback only.**

We'd like to enable Content Security Policy on GOV.UK, which provides additional security against cross-site scripting and other vulnerabilities in the site.

As part of this, we need to set an HTTP header to instruct the browser to not execute any JavaScript that it encounters in `<script>` tags on the page.

This is to defend against cases where somebody exploits GOV.UK and we are not adequately protected against script tags injected in the page by other means eg by a malicious author in a content management system.

This commit moves inline JavaScript into asset files that can be loaded from a whitelisted domain.

This commit has issues and should **not** be merged to master. The issues I know of are:

- The ERB in `ie-8.js` is not processed
- This will cause an extra 3 HTTP requests, including a delay in adding the `js-enabled` class to the body, which will probably have negative side effects

I'd appreciate feedback on ways to fix those issues and any other thoughts from people.
