### PR TITLE
Use new grid layout placeholders for the cookie and header bar

### DIFF
--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -236,16 +236,11 @@
 /* Global header bar */
 
 #global-header-bar {
-  @include outer-block;
-  .inner-block {
-    @include inner-block;
-  }
-  .header-bar {
-    height: 10px;
-    background-color: $govuk-blue;
-    @include ie-lte(8) {
-      font-size: 0;
-    }
+  @extend %site-width-container;
+  height: 10px;
+  background-color: $govuk-blue;
+  @include ie-lte(8) {
+    font-size: 0;
   }
 }
 
@@ -256,17 +251,14 @@
 }
 
 #global-cookie-message {
+  width: 100%;
   background-color: $light-blue-25;
   padding-top: 10px;
   padding-bottom: 10px;
-  .outer-block {
-    @include outer-block;
-  }
-  .inner-block {
-    @include inner-block;
-  }
   p {
+    @extend %site-width-container;
     @include core-16;
-    margin: 0;
+    margin-top: 0;
+    margin-bottom: 0;
   }
 }

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -68,15 +68,11 @@
     </div>
 
     <div id="global-cookie-message">
-      <div class="outer-block">
-        <div class="inner-block">
-          <% if content_for?(:cookie_message) %>
-            <%= yield :cookie_message %>
-          <% else %>
-            <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
-          <% end %>
-        </div>
-      </div>
+      <% if content_for?(:cookie_message) %>
+        <%= yield :cookie_message %>
+      <% else %>
+        <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+      <% end %>
     </div>
     <!--end global-cookie-message-->
 
@@ -99,11 +95,7 @@
 
     <%= yield :after_header %>
 
-    <div id="global-header-bar">
-      <div class="inner-block">
-        <div class="header-bar"></div>
-      </div>
-    </div>
+    <div id="global-header-bar"></div>
     <!--end global-header-bar-->
 
     <%= content_for?(:content) ? yield(:content) : yield %>


### PR DESCRIPTION
`inner-block` and `outer-block` have been deprecated, remove these
and replace with the new grid layout placeholders.

This affects the global header bar (the blue line underneath the
header) and the global cookie message (shown at first visit, or when js
is disabled).

Smaller screens:
![govuk-template-mobile](https://cloud.githubusercontent.com/assets/417754/5822290/ad455b9c-a0ca-11e4-94f2-036cf9287435.png)

Tablet:
![govuk-template-tablet](https://cloud.githubusercontent.com/assets/417754/5822292/b3f6c084-a0ca-11e4-9fc3-9901ed8ee56c.png)

Desktop:
![govuk-template-desktop](https://cloud.githubusercontent.com/assets/417754/5822282/a0f12ba0-a0ca-11e4-86c4-82da740f8025.png)