### PR TITLE
Add template location to "main" property in package.json

### DIFF
--- a/source/package.json.erb
+++ b/source/package.json.erb
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/alphagov/govuk_template_<%= template_abbreviation %>/issues",
   "license": "MIT",
   "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
+  "main": "views/layouts/govuk_template.html",
   "repository": {
     "type": "git",
     "url": "http://github.com/alphagov/govuk_template_<%= template_abbreviation %>.git"


### PR DESCRIPTION
It is useful when building modules which depend on the templates to be able to programmatically obtain the location of the template, especially so when installing as an npm package, as the install location may be dependent on other factors. Setting the "main" property of the package.json allows the full path of the tempalte to be ascertained using `require.resolve('govuk_template_*')` in a node environment.

See https://github.com/alphagov/govuk_template_mustache/issues/5