### PR TITLE
Update tests to reflect new package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+install:
+  # Ensure that Travis install is a no-op because `jenkins.sh`
+  # installs dependencies.
+  - echo "Not running Travis installation"
+script:
+  - ./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,4 +6,9 @@ rm -f Gemfile.lock
 git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
-bundle exec rake spec build:and_release_if_updated
+bundle exec rake spec
+
+# If $PUBLISH_TEMPLATE is set, try and release the template
+if [[ -n "$PUBLISH_TEMPLATE" ]]; then
+  bundle exec rake build:and_release_if_updated
+fi

--- a/spec/support/examples/package.json
+++ b/spec/support/examples/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/alphagov/govuk_template_mustache/issues",
   "license": "MIT",
   "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
+  "main": "views/layouts/govuk_template.html",
   "repository": {
     "type": "git",
     "url": "http://github.com/alphagov/govuk_template_mustache.git"

--- a/spec/support/examples/package_ejs.json
+++ b/spec/support/examples/package_ejs.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/alphagov/govuk_template_ejs/issues",
   "license": "MIT",
   "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
+  "main": "views/layouts/govuk_template.html",
   "repository": {
     "type": "git",
     "url": "http://github.com/alphagov/govuk_template_ejs.git"


### PR DESCRIPTION
@alext pointed out that the tests for this run on our own internal CI, but only for branches that are from the alphagov repo.

Fix the tests for changes in #130.

We should consider whether we want to make builds run in Travis (as well?) in this repository, given that this repo is more likely to receive pull requests from external contributors.