### PR TITLE
Update licence to correct format and date

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013 GDS
+Copyright (c) 2015 Crown Copyright (Government Digital Service)
 
 MIT License
 


### PR DESCRIPTION
As per instructions from @annashipman, the copyright for this project should read "Crown Copyright", not "HM Government".

It is also 2015 now.