### PR TITLE
Correction to copyright amendment

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013 GDS
+Copyright (c) 2013 Crown Copyright (Government Digital Service)
 
 MIT License
 

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Crown Copyright (Government Digital Service)
+Copyright (c) 2013 GDS
 
 MIT License
 


### PR DESCRIPTION
The copyright should match the format specified in https://github.com/alphagov/govuk_template/pull/132 but with the date kept to when the code was published.

Based on comments from @alext https://github.com/alphagov/govuk_template/pull/132#issuecomment-74061349 and advice from @bradleywright.