### PR TITLE
Remove inner and outer block mixins

### DIFF
--- a/source/assets/stylesheets/_footer.scss
+++ b/source/assets/stylesheets/_footer.scss
@@ -5,13 +5,13 @@
   border-top: 1px solid $footer-border-top;
 
   .footer-wrapper {
-    @include outer-block;
+    @extend %site-width-container;
+    background-color: $footer-background;
     padding-top: 20px;
+
     @include media(tablet) {
       padding-top: 60px;
     }
-    background-color: $footer-background;
-    margin: 0 auto;
   }
 
   a {
@@ -34,7 +34,6 @@
   }
 
   .footer-meta {
-    @include inner-block;
     @extend %contain-floats;
     padding-bottom: 60px;
     clear: both;


### PR DESCRIPTION
- Replace `outer-block` with new grid layout placeholder
`%site-width-container`
- Remove `inner-block` as the left and right margins are now set by `%site-width-container`

When the template is compiled, the Sass warnings for the deprecated
grid mixins will no longer appear.

![govuk_template_footer_tablet_nobg](https://cloud.githubusercontent.com/assets/417754/6214630/bd761056-b5f1-11e4-9e25-e9b618d53d3e.png)
![govuk_template_footer_desktop](https://cloud.githubusercontent.com/assets/417754/6214653/f14ab5c6-b5f1-11e4-81af-8f13388bd285.png)
![govuk_template_footer_mobile](https://cloud.githubusercontent.com/assets/417754/6214654/f3d09afe-b5f1-11e4-9bb9-d37ba0c6e533.png)
