### PR TITLE
Support custom homepage URLs for header link

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -81,7 +81,7 @@
       <div class="header-wrapper">
         <div class="header-global">
           <div class="header-logo">
-            <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
+            <a href="<%= content_for?(:govuk_homepage_url) ? yield(:govuk_homepage_url) : "https://www.gov.uk/" %>" title="Go to the GOV.UK homepage" id="logo" class="content">
               <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" width="35" height="31" alt=""> GOV.UK
             </a>
           </div>


### PR DESCRIPTION
In every environment, this link takes you to www.gov.uk. This seems unhelpful
when you're in an environment that isn't production as it takes you to a
different environment which can be hard to notice.

This already happens in preview, and now that we are adding GOV.UK Draft (which
is accessed on a different domain), there will be more users looking at the
frontend of GOV.UK in an environment that isn't on the www.gov.uk domain.

This will be paired with a change to static which will use Plek to get the
current website root and pass it in.