### PR TITLE
Support custom global header text

### DIFF
--- a/build_tools/compiler/ejs_processor.rb
+++ b/build_tools/compiler/ejs_processor.rb
@@ -18,6 +18,7 @@ module Compiler
       footer_support_links: partial_for(:footer_support_links),
       footer_top:           partial_for(:footer_top),
       homepage_url:         "{% if (homepageUrl) { %><%= homepageUrl %><% } else { %>https://www.gov.uk/<% } %>",
+      global_header_text:   "<% if (globalHeaderText) { %><%= globalHeaderText %><% } %>",
       head:                 partial_for(:head),
       header_class:         "<% if (headerClass) { %><%= headerClass %><% } %>",
       html_lang:            "<% if (htmlLang) { %><%= htmlLang %><% } else { %>en<% } %>",

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -18,6 +18,7 @@ module Compiler
       footer_support_links: block_for(:footer_support_links),
       footer_top:           block_for(:footer_top),
       homepage_url:         "{% homepage_url|default('https://www.gov.uk/')",
+      global_header_text:   "{{ global_header_text|default('GOV.UK') }}",
       head:                 block_for(:head),
       header_class:         block_for(:header_class),
       html_lang:            "{{ html_lang|default('en') }}",

--- a/build_tools/compiler/liquid_processor.rb
+++ b/build_tools/compiler/liquid_processor.rb
@@ -18,6 +18,7 @@ module Compiler
       footer_support_links: include_for(:footer_support_links),
       footer_top:           include_for(:footer_top),
       homepage_url:         "{% if page.homepage_url %}{{ page.homepage_url }}{% else %}https://www.gov.uk/{% endif %}",
+      global_header_text:   "{% if page.global_header_text %}{{ page.global_header_text }}{% endif %}",
       head:                 include_for(:head),
       header_class:         "{% if page.header_class %}{{ page.header_class }}{% endif %}",
       html_lang:            "{% if page.html_lang %}{{ page.html_lang }}{% else %}en{% endif %}",

--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -18,6 +18,7 @@ module Compiler
       footer_support_links: tag_for(:footerSupportLinks),
       footer_top:           tag_for(:footerTop),
       homepage_url:         "{{homepageUrl}}https://www.gov.uk/{{/homepageUrl}}",
+      global_header_text:   "{{$globalHeaderText}}GOV.UK{{/globalHeaderText}}",
       head:                 tag_for(:head),
       header_class:         tag_for(:headerClass),
       html_lang:            "{{$htmlLang}}en{{/htmlLang}}",

--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -22,6 +22,7 @@ module Compiler
       footer_support_links: unescaped_html_tag_for(:footerSupportLinks),
       footer_top:           unescaped_html_tag_for(:footerTop),
       homepage_url:         unescaped_html_tag_for(:homepageUrl),
+      global_header_text:   unescaped_html_tag_for(:globalHeaderText),
       head:                 unescaped_html_tag_for(:head),
       header_class:         unescaped_html_tag_for(:headerClass),
       html_lang:            tag_for(:htmlLang),

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -12,7 +12,7 @@ module Compiler
       # top_of_page has a special purpose: it is required by Play to define the
       # parameters to pass when rendering
       # https://www.playframework.com/documentation/2.2.x/ScalaTemplates#Template-parameters
-      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = Html.empty, propositionHeader:Html = Html.empty, homepageUrl:Html = Html.empty, cookieMessage:Html = Html.empty)(content:Html)',
+      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = Html.empty, propositionHeader:Html = Html.empty, homepageUrl:Html = Html.empty, globalHeaderText:Html = Html.empty, cookieMessage:Html = Html.empty)(content:Html)',
       head: '@head',
       body_classes: '@bodyClasses.getOrElse("")',
       header_class: '@headerClass',
@@ -24,7 +24,8 @@ module Compiler
       after_header: '@afterHeader',
       footer_top: '@footerTop',
       footer_support_links: '@footerLinks',
-      homepage_url: "@homepageUrl.getOrElse(\"https://www.gov.uk/\")",
+      homepage_url: '@homepageUrl.getOrElse("https://www.gov.uk/")',
+      global_header_text: '@globalHeaderText.getOrElse("GOV.UK")',
       cookie_message: <<-HTML
         if(@cookieMessage) {
           @cookieMessage

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -82,7 +82,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="<%= content_for?(:homepage_url) ? yield(:homepage_url) : "https://www.gov.uk/" %>" title="Go to the GOV.UK homepage" id="logo" class="content">
-              <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" width="35" height="31" alt=""> GOV.UK
+              <img src="<%= asset_path 'gov.uk_logotype_crown.png' %>" width="35" height="31" alt=""> <%= content_for?(:global_header_text) ? yield(:global_header_text) : "GOV.UK" %>
             </a>
           </div>
           <%= yield :inside_header %>


### PR DESCRIPTION
We want to be able to override the "GOV.UK" in the top left of the header with
"GOV.UK (Draft)" or similar to clearly signal when a user (eg a content editor)
is looking at Draft GOV.UK.