### PR TITLE
Fix a bug in the Mustache Inheritance template

### DIFF
--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -4,8 +4,8 @@ require_relative 'template_processor'
 module Compiler
   class MustacheInheritanceProcessor < TemplateProcessor
 
-    def self.tag_for(lowerCamelCaseKey)
-      "{{$#{lowerCamelCaseKey}}}{{/#{lowerCamelCaseKey}}}"
+    def self.tag_for(lowerCamelCaseKey, default_value="")
+      "{{$#{lowerCamelCaseKey}}}#{default_value}{{/#{lowerCamelCaseKey}}}"
     end
 
     @@yield_hash = {
@@ -17,13 +17,13 @@ module Compiler
       cookie_message:       tag_for(:cookieMessage),
       footer_support_links: tag_for(:footerSupportLinks),
       footer_top:           tag_for(:footerTop),
-      homepage_url:         "{{homepageUrl}}https://www.gov.uk/{{/homepageUrl}}",
-      global_header_text:   "{{$globalHeaderText}}GOV.UK{{/globalHeaderText}}",
+      homepage_url:         tag_for(:homepageUrl, "https://www.gov.uk/"),
+      global_header_text:   tag_for(:globalHeaderText, "GOV.UK"),
       head:                 tag_for(:head),
       header_class:         tag_for(:headerClass),
-      html_lang:            "{{$htmlLang}}en{{/htmlLang}}",
+      html_lang:            tag_for(:htmlLang, "en"),
       inside_header:        tag_for(:insideHeader),
-      page_title:           "{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}",
+      page_title:           tag_for(:pageTitle, "GOV.UK - The best place to find government services and information"),
       proposition_header:   tag_for(:propositionHeader),
       top_of_page:          tag_for(:topOfPage),
     }


### PR DESCRIPTION
There was a missing $ in the opening tag, which was syntactically invalid.

This was highlighted by the integration test in the branch.