### PR TITLE
Fix jenkins.sh

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
The `[[` syntax used on line 12 seems to be bash-specific, but we weren't
specifying bash, just any old shell.

It was causing this error:
`./jenkins.sh: 12: ./jenkins.sh: [[: not found`