### PR TITLE
Remove fix for Windows Safari print styles

### DIFF
--- a/source/assets/javascripts/core.js
+++ b/source/assets/javascripts/core.js
@@ -1,20 +1,6 @@
 (function() {
   "use strict"
 
-  // fix for printing bug in Windows Safari
-  var windowsSafari = (window.navigator.userAgent.match(/(\(Windows[\s\w\.]+\))[\/\(\s\w\.\,\)]+(Version\/[\d\.]+)\s(Safari\/[\d\.]+)/) !== null),
-      style;
-
-  if (windowsSafari) {
-    // set the New Transport font to Arial for printing
-    style = document.createElement('style');
-    style.setAttribute('type', 'text/css');
-    style.setAttribute('media', 'print');
-    style.innerHTML = '@font-face { font-family: nta !important; src: local("Arial") !important; }';
-    document.getElementsByTagName('head')[0].appendChild(style);
-  }
-
-
   // add cookie message
   if (window.GOVUK && GOVUK.addCookieMessage) {
     GOVUK.addCookieMessage();


### PR DESCRIPTION
The print styles no longer include the New Transport font so this fix isn't required.

See this commit for details:

https://github.com/alphagov/govuk_frontend_toolkit/commit/55b7ac72ebe5a0057285cebd5ab48511be3facb4