### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.14.0
+
+- Update the font-files and move woffs into CSS
+- All user-visible text in the template can now be overridden. Some template languages which don't support default values (such as plain mustache) will therefore lose that text and require you to handle supplying the default.
+
 # 0.13.0
 
 - Add WebJar package

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.13.0"
+  VERSION = "0.14.0"
 end


### PR DESCRIPTION
Most of the changes are internal to the build/test parts of the gem rather than the templates that are generated, so I omitted those from the changelog.

https://github.com/alphagov/govuk_template/compare/v0.13.0...644a50e8ac39e1648be07d2d8cb81bf37d3346ab

cc @froddd 