### PR TITLE
Update Crown Copyright link.

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -120,7 +120,7 @@
           </div>
 
           <div class="copyright">
-            <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm"><%= content_for?(:crown_copyright_message) ? yield(:crown_copyright_message) : "&copy; Crown copyright" %></a>
+            <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/"><%= content_for?(:crown_copyright_message) ? yield(:crown_copyright_message) : "&copy; Crown copyright" %></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The original link was redirecting to the new address, so updating this.

Coincidentally they seem to have moved to `http` from `https`. The same content gets served at via `https`, but the javascript doesn’t load as it is served from an `http` address which causes their menu to appear.