### PR TITLE
Fix Jenkins CI build

### DIFF
--- a/integration_tests/integrations/mustache/build.sh
+++ b/integration_tests/integrations/mustache/build.sh
@@ -6,6 +6,6 @@ rm -rf vendor/mustache_govuk_template/*
 # TODO: Pick the latest, not every matching tgz file!
 tar -zxvf ../../../pkg/mustache_govuk_template-*.tgz -C vendor/
 
-bundle install
+bundle install --path vendor/bundle
 
 bundle exec ruby test_render.rb

--- a/integration_tests/integrations/rails/.gitignore
+++ b/integration_tests/integrations/rails/.gitignore
@@ -1,0 +1,1 @@
+vendor/bundle

--- a/integration_tests/integrations/rails/build.sh
+++ b/integration_tests/integrations/rails/build.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 set -e
 
-bundle install
+bundle install --path vendor/bundle
 
 bundle exec ruby simplicity.rb


### PR DESCRIPTION
The two integration apps were running bundler without specifying a path to
install to, which meant that bundler was installing gems system-wide. On our
Jenkins CI, the user doesn't have privileges to install system-wide, so the
build was failing.

Thanks to @alext for doing the detective work.