### PR TITLE
Don't escape output of statement_tag_for (Jinja)

### DIFF
--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -9,7 +9,7 @@ module Compiler
     end
 
     def self.statement_tag_for(key, default_value)
-      "{{ #{key}|default('#{default_value}') }}"
+      "{{ #{key}|default('#{default_value}')|safe }}"
     end
 
     @@yield_hash = {

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -9,6 +9,10 @@ module Compiler
     end
 
     def self.statement_tag_for(key, default_value)
+      "{{ #{key}|default('#{default_value}') }}"
+    end
+
+    def self.unescaped_statement_tag_for(key, default_value)
       "{{ #{key}|default('#{default_value}')|safe }}"
     end
 
@@ -32,7 +36,7 @@ module Compiler
       skip_link_message:    statement_tag_for(:skip_link_message, 'Skip to main content'),
       logo_link_title:      statement_tag_for(:logo_link_title, 'Go to the GOV.UK homepage'),
       licence_message:      block_for(:licence_message, '<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>'),
-      crown_copyright_message: statement_tag_for(:crown_copyright_message, '&copy; Crown copyright'),
+      crown_copyright_message: unescaped_statement_tag_for(:crown_copyright_message, '&copy; Crown copyright'),
     }
 
     def handle_yield(section = :layout)

--- a/spec/build_tools/compiler/jinja_processor_spec.rb
+++ b/spec/build_tools/compiler/jinja_processor_spec.rb
@@ -12,11 +12,12 @@ def valid_sections
     footer_top: "{% block footer_top %}{% endblock %}",
     head: "{% block head %}{% endblock %}",
     header_class: "{% block header_class %}{% endblock %}",
-    html_lang: "{{ html_lang|default('en')|safe }}",
+    html_lang: "{{ html_lang|default('en') }}",
     inside_header: "{% block inside_header %}{% endblock %}",
     page_title: "{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}",
     proposition_header: "{% block proposition_header %}{% endblock %}",
-    top_of_page: "{% block top_of_page %}{% endblock %}"
+    top_of_page: "{% block top_of_page %}{% endblock %}",
+    crown_copyright_message: "{{ crown_copyright_message|default('&copy; Crown copyright')|safe }}"
 
   }
 end

--- a/spec/build_tools/compiler/jinja_processor_spec.rb
+++ b/spec/build_tools/compiler/jinja_processor_spec.rb
@@ -12,7 +12,7 @@ def valid_sections
     footer_top: "{% block footer_top %}{% endblock %}",
     head: "{% block head %}{% endblock %}",
     header_class: "{% block header_class %}{% endblock %}",
-    html_lang: "{{ html_lang|default('en') }}",
+    html_lang: "{{ html_lang|default('en')|safe }}",
     inside_header: "{% block inside_header %}{% endblock %}",
     page_title: "{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}",
     proposition_header: "{% block proposition_header %}{% endblock %}",


### PR DESCRIPTION
The Jinja template tags generated by this compiler escape any variables passed to them.

So when you pass a string like `&copy; Crown Copyright` what gets spat out into the source of the page is `&amp;copy; Crown Copyright`, which in a browser looks like:

![image](https://cloud.githubusercontent.com/assets/355079/8652617/83b81220-2977-11e5-9b0f-bc79d7e66c1b.png)

This commit adds a [Jinja filter called 'safe'](http://jinja.pocoo.org/docs/dev/templates/#working-with-automatic-escaping) which prevents escaping of special characters.