### PR TITLE
👻 Move inside_header to stop being invisible 🙈

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -83,9 +83,9 @@
           <div class="header-logo">
             <a href="<%= content_for?(:homepage_url) ? yield(:homepage_url) : "https://www.gov.uk/" %>" title="<%= content_for?(:logo_link_title) ? yield(:logo_link_title) : "Go to the GOV.UK homepage" %>" id="logo" class="content">
               <img src="<%= asset_path 'gov.uk_logotype_crown_invert_trans.png' %>" width="35" height="31" alt=""> <%= content_for?(:global_header_text) ? yield(:global_header_text) : "GOV.UK" %>
+              <%= yield :inside_header %>
             </a>
           </div>
-          <%= yield :inside_header %>
         </div>
         <%= yield :proposition_header %>
       </div>


### PR DESCRIPTION
- When adding e.g. 'GOV.UK' as inner header content we were getting a hidden piece of content and no link
- This should put that text into the anchor link and make it visible again

## Before
![screen shot 2015-08-17 at 16 04 05](https://cloud.githubusercontent.com/assets/120181/9308075/dadfa638-44f9-11e5-9b37-f0046d53736d.png)

## After
![screen shot 2015-08-17 at 16 03 47](https://cloud.githubusercontent.com/assets/120181/9308076/dae9ec60-44f9-11e5-85c1-36291ed0391f.png)
