### PR TITLE
Fix the jump on logo hover

### DIFF
--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -72,7 +72,7 @@
   #logo {
     float: left;
     position: relative;
-    top: 1px;
+    top: -1px;
 
     height: 30px;
     overflow: visible;
@@ -84,8 +84,9 @@
     line-height: 1em;
     text-decoration: none;
     text-rendering: optimizeLegibility;
-    margin-bottom: -1px;
-    padding-top: 1px;
+    margin-bottom: -3px;
+    padding-top: 2px;
+    border-bottom: 1px solid transparent;
 
     background: image-url('images/gov.uk_logotype_crown.png') no-repeat;
     background-size: 35px 31px;
@@ -96,7 +97,7 @@
 
     img {
       position: relative;
-      top: -1px;
+      top: -2px;
 
       width: 35px;
       height: 31px;
@@ -114,8 +115,7 @@
     &:hover,
     &:focus {
       text-decoration: none;
-      border-bottom: 1px solid;
-      padding-bottom: 0;
+      border-bottom-color: $white;
     }
 
     &:active {


### PR DESCRIPTION
This also moves the crown into the original position, and stops the browser from reflowing on hover of the logo.