### PR TITLE
The copyright logo is safe

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -120,7 +120,7 @@
           </div>
 
           <div class="copyright">
-            <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/"><%= content_for?(:crown_copyright_message) ? yield(:crown_copyright_message) : "&copy; Crown copyright" %></a>
+            <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/"><%= content_for?(:crown_copyright_message) ? yield(:crown_copyright_message) : "© Crown copyright" %></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Otherwise the `&` on the `&copy;` gets turned into `&amp;` which means
the footer reads as "&copy; Crown copyright"