### PR TITLE
Only send email notifications on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ install:
   - echo "Not running Travis installation"
 script:
   - ./jenkins.sh
+notifications:
+  email:
+    on_success: never
+    on_failure: always


### PR DESCRIPTION
Getting an email every time you push a passing commit can get
frustrating. The interface lets you know anyway so only notify on
failure. This matches the way that we have our internal CI setup.