### PR TITLE
Fix extended footer on certain pages

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -25,7 +25,9 @@
 .visuallyhidden {
   position: absolute;
   left: -9999em;
-  height: 0;
+  top: auto;
+  width: 1px;
+  height: 1px;
   overflow: hidden;
 
   /*

--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -25,6 +25,8 @@
 .visuallyhidden {
   position: absolute;
   left: -9999em;
+  height: 0;
+  overflow: hidden;
 
   /*
    * Extends the .visuallyhidden class to allow the element to be


### PR DESCRIPTION
Some pages (e.g. https://www.gov.uk/government/publications/armed-forces-corporate-covenant-signed-pledges) have a long revision history. This, by default, has a class of `visuallyhidden` that hides the extended content off screen using `position:absolute` and `left:-9999em`. While this is hidden, the viewport will extend itself to include absolutely positioned elements, even if they’re positioned horizontally off screen.

This patch clips off screen elements so that they don’t take up any vertical space. It doesn’t affect VoiceOver’s ability to read the extended content.