### PR TITLE
Don't change logo link text colour in active state

### DIFF
--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -117,10 +117,6 @@
       text-decoration: none;
       border-bottom-color: $white;
     }
-
-    &:active {
-      color: $light-blue;
-    }
   }
   .header-proposition {
     padding-top: 10px;


### PR DESCRIPTION
The active state was setting the logo link text to blue, which looked briefly weird when clicking the logo.

By not changing the link colour for the active state it will default to the non-active link colour (white).


| Before | After |
| --- | --- |
|  ![screenshot 2016-01-12 15 13 35](https://cloud.githubusercontent.com/assets/63201/12267424/f3147c28-b93f-11e5-8fe3-74946e8634da.png) | ![screenshot 2016-01-12 15 10 27](https://cloud.githubusercontent.com/assets/63201/12267425/f324c25e-b93f-11e5-91ca-51a8dac8e653.png) |

(Reported by @jordanhatch)
