### PR TITLE
[do not merge] Fix TravisCI builds by updating bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+before_install:
+   # Travis bundler versions are quite out of date and can cause install errors
+   # see: https://github.com/rubygems/rubygems/issues/1419
+   - gem update bundler
 install:
   # Ensure that Travis install is a no-op because `jenkins.sh`
   # installs dependencies.


### PR DESCRIPTION
The TravisCI version of bundler is out of date, which can cause some problems
install dependencies. Updating bundler as part of the install setup is the
fix recommended by Travis (See https://github.com/travis-ci/travis-ci/issues/3531)

I was seeing it another govuk_template branch:
- https://travis-ci.org/alphagov/govuk_template/builds/102056609

There is an identical fix for govspeak:
- https://github.com/alphagov/govspeak/commit/1135adab9d1e4404b9a903ee1ffb35f7ebbeb21e

More info:
- https://github.com/rubygems/rubygems/issues/1419
- https://github.com/thoughtbot/factory_girl/pull/846