### PR TITLE
Allow overriding / removal of OGL logo in the footer

### DIFF
--- a/build_tools/compiler/django_processor.rb
+++ b/build_tools/compiler/django_processor.rb
@@ -32,6 +32,7 @@ module Compiler
       top_of_page:          "{% load staticfiles %}" + block_for(:top_of_page),
       skip_link_message:    statement_tag_for(:skip_link_message, 'Skip to main content'),
       logo_link_title:      statement_tag_for(:logo_link_title, 'Go to the GOV.UK homepage'),
+      licence_logo:         block_for(:licence_logo, '<p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>'),
       licence_message:      block_for(:licence_message, '<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>'),
       crown_copyright_message: statement_tag_for(:crown_copyright_message, '&copy; Crown copyright'),
     }

--- a/build_tools/compiler/ejs_processor.rb
+++ b/build_tools/compiler/ejs_processor.rb
@@ -28,6 +28,7 @@ module Compiler
       top_of_page:          partial_for(:top_of_page),
       skip_link_message:    "<% if (skipLinkMessage) { %><%= skipLinkMessage %><% } else { %>Skip to main content<% } %>",
       logo_link_title:      "<% if (logoLinkTitle) { %><%= logoLinkTitle %><% } else { %>Go to the GOV.UK homepage<% } %>",
+      licence_logo:         partial_for(:licence_logo),
       licence_message:      partial_for(:licence_message),
       crown_copyright_message: "<% if (crownCopyrightMessage) { %><%= crownCopyrightMessage %><% } else { %>&copy; Crown copyright<% } %>",
     }

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -36,6 +36,7 @@ module Compiler
       top_of_page:          block_for(:top_of_page),
       skip_link_message:    statement_tag_for(:skip_link_message, 'Skip to main content'),
       logo_link_title:      statement_tag_for(:logo_link_title, 'Go to the GOV.UK homepage'),
+      licence_logo:         block_for(:licence_logo, '<p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>'),
       licence_message:      block_for(:licence_message, '<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>'),
       crown_copyright_message: unescaped_statement_tag_for(:crown_copyright_message, '&copy; Crown copyright'),
     }

--- a/build_tools/compiler/liquid_processor.rb
+++ b/build_tools/compiler/liquid_processor.rb
@@ -28,6 +28,7 @@ module Compiler
       top_of_page:          include_for(:top_of_page),
       skip_link_message:    "{% if page.skip_link_message %}{{ page.skip_link_message }}{% else %}Skip to main content{% endif %}",
       logo_link_title:      "{% if page.logo_link_title %}{{ page.logo_link_title }}{% else %}Go to the GOV.UK homepage{% endif %}",
+      licence_logo:         include_for(:licence_logo),
       licence_message:      include_for(:licence_message),
       crown_copyright_message: "{% if page.crown_copyright_message %}{{ page.crown_copyright_message }}{% else %}&copy; Crown copyright{% endif %}",
     }

--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -28,6 +28,7 @@ module Compiler
       top_of_page:          tag_for(:topOfPage),
       skip_link_message:    tag_for(:skipLinkMessage, 'Skip to main content'),
       logo_link_title:      tag_for(:logoLinkTitle, 'Go to the GOV.UK homepage'),
+      licence_logo:         tag_for(:licenceLogo, '<p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>'),
       licence_message:      tag_for(:licenceMessage, '<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>'),
       crown_copyright_message: tag_for(:crownCopyrightMessage, '&copy; Crown copyright'),
     }

--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -32,6 +32,7 @@ module Compiler
       top_of_page:          unescaped_html_tag_for(:topOfPage),
       skip_link_message:    tag_for(:skipLinkMessage),
       logo_link_title:      tag_for(:logoLinkTitle),
+      licence_logo:         unescaped_html_tag_for(:licenceLogo),
       licence_message:      unescaped_html_tag_for(:licenceMessage),
       crown_copyright_message: tag_for(:crownCopyrightMessage),
     }

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -12,7 +12,7 @@ module Compiler
       # top_of_page has a special purpose: it is required by Play to define the
       # parameters to pass when rendering
       # https://www.playframework.com/documentation/2.2.x/ScalaTemplates#Template-parameters
-      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = Html.empty, propositionHeader:Html = Html.empty, homepageUrl:Html = Html.empty, globalHeaderText:Html = Html.empty, cookieMessage:Html = Html.empty, skipLinkMessage:Html, logoLinkTitle:Html, licenceMessage:Html, crownCopyrightMessage:Html)(content:Html)',
+      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = Html.empty, propositionHeader:Html = Html.empty, homepageUrl:Html = Html.empty, globalHeaderText:Html = Html.empty, cookieMessage:Html = Html.empty, skipLinkMessage:Html, logoLinkTitle:Html, licenceLogo:Html, licenceMessage:Html, crownCopyrightMessage:Html)(content:Html)',
       head: '@head',
       body_classes: '@bodyClasses.getOrElse("")',
       header_class: '@headerClass',

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -29,6 +29,7 @@ module Compiler
       cookie_message: '@cookieMessage.getOrElse(\'<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>\')',
       skip_link_message: '@skipLinkMessage.getOrElse("Skip to main content")',
       logo_link_title: '@logoLinkTitle.getOrElse("Go to the GOV.UK homepage")',
+      licence_logo: '@licenceLogo',
       licence_message: '@licenceMessage',
       crown_copyright_message: '@crownCopyrightMessage.getOrElse("&copy; Crown copyright")',
     }

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -110,7 +110,12 @@
             <%= yield :footer_support_links %>
 
             <div class="open-government-licence">
-              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+              <% if content_for?(:licence_logo) %>
+                <%= yield :licence_logo %>
+              <% else %>
+                <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+              <% end %>
+
               <% if content_for?(:licence_message) %>
                 <%= yield :licence_message %>
               <% else %>


### PR DESCRIPTION
As per #188, I am working on a service for which I have been asked to remove the OGL logo and message from the footer. The reason being that some of the information contains personal information such as names and addresses and is not "open". In addition, users are required to purchase the information - it is not freely available.

I have tried to follow the conventions used by the licence message in the footer but I am quite new to using the kit so not 100% sure if I have done this in the right way.

One thing I am aware of is that I might need to make a corresponding change to this file in the govuk_elements repo? https://github.com/alphagov/govuk_elements/blob/master/lib/template-config.js