### PR TITLE
Add static files to `assets.precompile`

### DIFF
--- a/lib/govuk_template/engine.rb
+++ b/lib/govuk_template/engine.rb
@@ -2,11 +2,19 @@ module GovukTemplate
   class Engine < ::Rails::Engine
     initializer "govuk_template.assets.precompile" do |app|
       app.config.assets.precompile += %w(
+        favicon.ico
         govuk-template*.css
         fonts*.css
         govuk-template.js
         ie.js
         vendor/goog/webfont-debug.js
+        apple-touch-icon-120x120.png
+        apple-touch-icon-152x152.png
+        apple-touch-icon-60x60.png
+        apple-touch-icon-76x76.png
+        gov.uk_logotype_crown_invert.png
+        gov.uk_logotype_crown_invert_trans.png
+        opengraph-image.png
       )
     end
   end


### PR DESCRIPTION
This avoids errors when gem is used with sprockets-rails >= 3