### PR TITLE
Generate package.json for the Jinja version of the template

### DIFF
--- a/build_tools/packager/jinja_packager.rb
+++ b/build_tools/packager/jinja_packager.rb
@@ -20,6 +20,15 @@ module Packager
       end
     end
 
+    def generate_package_json
+      template_abbreviation = "jinja"
+      template_name = "Jinja"
+      contents = ERB.new(File.read(File.join(@repo_root, "source/package.json.erb"))).result(binding)
+      File.open(File.join(@target_dir, "package.json"), "w") do |f|
+        f.write contents
+      end
+    end
+
     def process_template(file)
       target_dir = @target_dir.join(File.dirname(file))
       target_dir.mkpath


### PR DESCRIPTION
This PR copies the package.json generator from the mustache packager.

Adding a `package.json` file ensures the [GOV.UK Prototype Kit](https://github.com/alphagov/govuk_prototype_kit/blob/master/package.json#L38) (amongst other projects) can use the Jinja version of the template as a dependency, without requiring [napa](https://www.npmjs.com/package/napa) as an additional dependency.

Napa is used a workaround, because the Jinja version of the GOV.UK template is missing the `package.json` file.

cc. @dsingleton @quis.