### PR TITLE
Add integration test for Jinja template

### DIFF
--- a/integration_tests/integrations/jinja/.gitignore
+++ b/integration_tests/integrations/jinja/.gitignore
@@ -1,0 +1,2 @@
+vendor/*
+.env

--- a/integration_tests/integrations/jinja/build.py
+++ b/integration_tests/integrations/jinja/build.py
@@ -1,0 +1,16 @@
+from jinja2 import Environment, FileSystemLoader
+
+env = Environment(loader=FileSystemLoader([
+    'vendor/jinja_govuk_template/views/layouts',
+    'templates'
+]))
+template = env.get_template('test_template.html')
+content = template.render({
+    "html_lang": "rb",
+    "skip_link_message": "Custom skip link text",
+    "logo_link_title": "Custom logo link title text",
+    "crown_copyright_message": "Custom crown copyright message text",
+})
+
+with open("../../html_for_testing/jinja_integration_test_app.html", "w") as static_file:
+    static_file.write(content)

--- a/integration_tests/integrations/jinja/build.sh
+++ b/integration_tests/integrations/jinja/build.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+set -e
+
+rm -rf vendor/jinja_govuk_template/*
+
+mkdir -p vendor/jinja_govuk_template
+
+# strip-components lets us decompress into a directory without a version number
+# TODO: Pick the latest, not every matching tgz file!
+tar -zxf ../../../pkg/jinja_govuk_template-*.tgz -C vendor/jinja_govuk_template --strip-components 1
+
+# --user param allows installing without sudo:
+pip install virtualenv --user
+virtualenv .env
+source .env/bin/activate
+
+pip install jinja2
+
+python build.py

--- a/integration_tests/integrations/jinja/templates/test_template.html
+++ b/integration_tests/integrations/jinja/templates/test_template.html
@@ -1,0 +1,29 @@
+{% extends "govuk_template.html" %}
+
+{% block page_title %}This is a custom page title{% endblock page_title %}
+
+{% block head %}<inserted-into-head></inserted-into-head>{% endblock head %}
+
+{% block body_classes %}custom_body_class{% endblock body_classes %}
+
+{% block body_start %}<inserted-into-body-start></inserted-into-body-start>{% endblock body_start %}
+
+{% block cookie_message %}Custom cookie message{% endblock cookie_message %}
+
+{% block header_class %}custom_header_class{% endblock header_class %}
+
+{% block inside_header %}<inside-header></inside-header>{% endblock inside_header %}
+
+{% block proposition_header %}<proposition-header></proposition-header>{% endblock proposition_header %}
+
+{% block after_header %}<after-header></after-header>{% endblock after_header %}
+
+{% block content %}The page content{% endblock content %}
+
+{% block footer_top %}<footer-top></footer-top>{% endblock footer_top %}
+
+{% block footer_support_links %}<footer-support-links></footer-support-links>{% endblock footer_support_links %}
+
+{% block licence_message %}Custom license message text{% endblock licence_message %}
+
+{% block body_end %}<body-end></body-end>{% endblock body_end %}


### PR DESCRIPTION
This test is almost exactly the same as a the Django one, but using Jinja to render the templates instead.

This is to make sure that any changes to the template that use Nunchucks-only features will be caught by the integration tests.

This is to avoid having to maintain two separate, but identical versions of the template for the two different languages, as discussed in #193.