### PR TITLE
Add integration test for Nunjucks renderer

### DIFF
--- a/integration_tests/integrations/nunjucks/.gitignore
+++ b/integration_tests/integrations/nunjucks/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+vendor/*

--- a/integration_tests/integrations/nunjucks/build.js
+++ b/integration_tests/integrations/nunjucks/build.js
@@ -1,0 +1,20 @@
+var nunjucks = require('nunjucks'),
+    fs = require('fs'),
+    path = require('path'),
+    env;
+
+env = new nunjucks.Environment(new nunjucks.FileSystemLoader([
+  path.normalize(__dirname + '/templates/'),
+  path.normalize(__dirname + '/vendor/jinja_govuk_template/views/layouts/')
+]));
+
+fs.writeFileSync(
+  path.normalize(__dirname + '/../../html_for_testing/nunchucks_integration_test_app.html'),
+  env.render('test_template.html', {
+      'html_lang': 'rb',
+      'skip_link_message': 'Custom skip link text',
+      'logo_link_title': 'Custom logo link title text',
+      'crown_copyright_message': 'Custom crown copyright message text',
+  }),
+  { encoding : 'utf-8' }
+);

--- a/integration_tests/integrations/nunjucks/build.sh
+++ b/integration_tests/integrations/nunjucks/build.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+set -e
+
+rm -rf vendor/jinja_govuk_template/*
+
+mkdir -p vendor/jinja_govuk_template
+
+# strip-components lets us decompress into a directory without a version number
+# TODO: Pick the latest, not every matching tgz file!
+tar -zxf ../../../pkg/jinja_govuk_template-*.tgz -C vendor/jinja_govuk_template --strip-components 1
+
+npm install
+
+node build.js

--- a/integration_tests/integrations/nunjucks/package.json
+++ b/integration_tests/integrations/nunjucks/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nunjucks_integration_test_app",
+  "description": "govuk_template integration test app for nunjucks",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": "0.10.x"
+  },
+  "dependencies": {
+    "nunjucks": "2.3.0"
+  }
+}

--- a/integration_tests/integrations/nunjucks/templates/test_template.html
+++ b/integration_tests/integrations/nunjucks/templates/test_template.html
@@ -1,0 +1,29 @@
+{% extends "govuk_template.html" %}
+
+{% block page_title %}This is a custom page title{% endblock %}
+
+{% block head %}<inserted-into-head></inserted-into-head>{% endblock %}
+
+{% block body_classes %}custom_body_class{% endblock %}
+
+{% block body_start %}<inserted-into-body-start></inserted-into-body-start>{% endblock %}
+
+{% block cookie_message %}Custom cookie message{% endblock %}
+
+{% block header_class %}custom_header_class{% endblock %}
+
+{% block inside_header %}<inside-header></inside-header>{% endblock %}
+
+{% block proposition_header %}<proposition-header></proposition-header>{% endblock %}
+
+{% block after_header %}<after-header></after-header>{% endblock %}
+
+{% block content %}The page content{% endblock %}
+
+{% block footer_top %}<footer-top></footer-top>{% endblock %}
+
+{% block footer_support_links %}<footer-support-links></footer-support-links>{% endblock %}
+
+{% block licence_message %}Custom license message text{% endblock %}
+
+{% block body_end %}<body-end></body-end>{% endblock %}


### PR DESCRIPTION
This commit adds an integration test for rendering the **Jinja** GOV.UK Template with the **[Nunjucks]( https://mozilla.github.io/nunjucks/)** template rendering engine. The test setup is based on the Mustache inheritance one.

The two templating languages are [mostly](http://mozilla.github.io/nunjucks/faq.html#can-i-use-the-same-templates-between-nunjucks-and-jinja2-what-are-the-differences) compatible. Having a test will ensure that we don’t get caught out by any of the incompatibilities.

This is to avoid having to maintain two separate, but identical versions of the template for the two different languages, as discussed in #193.