### PR TITLE
Release version 0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.16.3
+
+- make the Django version of the template into a proper Python package
+- publish the Jinja version of the template with a `package.json` for those
+  consuming it with NPM
+
 # 0.16.2
 
 - more static assets added to `assets.precompile` to improve

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.16.2"
+  VERSION = "0.16.3"
 end


### PR DESCRIPTION
## Summary of changes from 0.16.2
> - make the Django version of the template into a proper Python package
> - publish the Jinja version of the template with a `package.json` for those
>   consuming it with NPM

## Complete diff
https://github.com/alphagov/govuk_template/compare/v0.16.2...quis:release-0.16.3