### PR TITLE
Run the code to generate package.json for Jinja

### DIFF
--- a/build_tools/packager/jinja_packager.rb
+++ b/build_tools/packager/jinja_packager.rb
@@ -16,6 +16,7 @@ module Packager
       @target_dir.mkpath
       Dir.chdir(@target_dir) do |dir|
         prepare_contents
+        generate_package_json
         create_tarball
       end
     end


### PR DESCRIPTION
Although the Jinja packager had a method for generating a `package.json`, it wasn’t being called from anywhere.

**Tested locally:**

Before:
![image](https://cloud.githubusercontent.com/assets/355079/13011383/6b07b9b8-d19e-11e5-88fe-75aa82ba0b50.png)

After:
![image](https://cloud.githubusercontent.com/assets/355079/13011390/72e812ae-d19e-11e5-8e66-e08615dc8754.png)
