### PR TITLE
Version 0.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.16.4
+
+- Fix publish the Jinja version of the template with a `package.json` for those
+  consuming it with NPM
+
 # 0.16.3
 
 - make the Django version of the template into a proper Python package

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.16.3"
+  VERSION = "0.16.4"
 end


### PR DESCRIPTION
This version fixes 0.16.3 to include a package.json file with the Jinja
version of the GOV.UK template.

Tested using `bundle exec rake build:jinja`, the package.json file:

```
{
  "name": "govuk_template_jinja",
  "version": "0.16.4",
  "description": "Jinja packaged version of the GOV.UK template",
  "keywords": ["alphagov", "govuk", "jinja", "template"],
  "bugs": "https://github.com/alphagov/govuk_template_jinja/issues",
  "license": "MIT",
  "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
  "main": "views/layouts/govuk_template.html",
  "repository": {
    "type": "git",
    "url": "http://github.com/alphagov/govuk_template_jinja.git"
  }
}
```

cc. @quis, @dsingleton.