### PR TITLE
Add new colour variables to replace deprecated greys

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -45,7 +45,7 @@ html {
   -webkit-text-size-adjust: 100%; /* 1 */
   -ms-text-size-adjust: 100%; /* 1 */
   // Set background colour to match footer background
-  background-color: $grey-8;
+  background-color: $footer-background;
 }
 
 /*

--- a/source/assets/stylesheets/_footer.scss
+++ b/source/assets/stylesheets/_footer.scss
@@ -1,8 +1,8 @@
 /* Global footer */
 
 #footer {
-  background-color: $grey-8;
-  border-top: 1px solid $grey-6;
+  background-color: $footer-background;
+  border-top: 1px solid $footer-border-top;
 
   .footer-wrapper {
     @include outer-block;
@@ -10,22 +10,22 @@
     @include media(tablet) {
       padding-top: 60px;
     }
-    background-color: $grey-8;
+    background-color: $footer-background;
     margin: 0 auto;
   }
 
   a {
-    color: $grey-3;
+    color: $footer-link;
 
     &:hover {
-      color: $grey-1;
+      color: $footer-link-hover;
     }
   }
 
   h2 {
     @include core-24;
     font-weight: bold;
-    color: $grey-1;
+    color: $footer-text;
     margin: 0;
 
     a {
@@ -39,7 +39,7 @@
     padding-bottom: 60px;
     clear: both;
     font-size: 0;
-    color: $grey-3;
+    color: $footer-text;
 
     .footer-meta-inner {
       display: inline-block;

--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -189,7 +189,7 @@
         float: left;
         width: 50%;
         padding: 3px 0;
-        border-bottom: 1px solid $grey-2;
+        border-bottom: 1px solid $proposition-border;
 
         @include media(desktop){
           display: block;

--- a/source/assets/stylesheets/styleguide/_colours.scss
+++ b/source/assets/stylesheets/styleguide/_colours.scss
@@ -1,16 +1,12 @@
+// GOV.UK template colours
+
+$proposition-border: #2e3133;
 // Based on GOV.UK brand blue but slightly lighter so it hits contrast on the
 // black header bar when used as copy colour.
 $proposition-active-nav: #1d8feb;
 
-
-/* Old depricated greys, new things should use the toolkit greys */
-$grey-0: #0b0c0c;
-$grey-1: #171819;
-$grey-2: #2e3133;
-$grey-3: #454a4c;
-$grey-4: #5c6366;
-$grey-5: #8a9499;
-$grey-6: #a1acb2;
-$grey-7: #b8c6cc;
-$grey-8: #DEE0E2;
-$grey-9: #eaedef;
+$footer-background: $grey-3;
+$footer-border-top: #a1acb2;
+$footer-link: #454a4c;
+$footer-link-hover: #171819;
+$footer-text: $footer-link;


### PR DESCRIPTION
Create a new set of Sass colour variables, which are used only by GOV.UK template.

Also delete the old `$grey` variables, which were overriding those set by the GOV.UK front end toolkit.

The `_base.scss` file used by GOV.UK elements has [been renamed and updated to only include base styles](https://github.com/alphagov/govuk_elements/pull/176) which aren't specific to the GOV.UK template - so it no longer copies the footer background colour on the html element.

