### PR TITLE
Add a hook for hidden content when JS is enabled

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -13,7 +13,9 @@
 }
 
 /* Hide for both screenreaders and browsers */
-.hidden {
+.hidden,
+/* Hide for both screenreaders and browsers when JS enabled */
+.js-enabled .js-hidden {
   display: none;
   visibility: hidden;
 }


### PR DESCRIPTION
Some content we want to be hidden by default when JS is available, eg a toggle, where the content is initially hidden.

Hiding it with JS will usually give a flash/re-layout, as there will be a delay between the page initially loading and the JS executing and hiding the content itself.

Instead, we can use the `js-enabled` [class] that is set on `body` before content loads, to conditionally hide `js-hidden` content.

We already do this is some [other], [apps], and we're going to need it for the Toggle JS module we're going to use with Govspeak attachments, so it makes sense to do it at a lower, more common, level. govuk_template is also where `js-enabled` gets set, so it makes sense to add the hook here too.

[class]: https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb#L57
[other]: https://github.com/alphagov/govuk_elements/blob/a860e4d9e75f8bd390a80efb607778f95756ea53/public/sass/elements/_helpers.scss#L48-L51
[apps]: https://github.com/alphagov/whitehall/blob/5631a1722e186b194f4f7bb1f53cd2eb56e48034/app/assets/stylesheets/frontend/global/_js-hidden.scss

The _risk_ of this change, is a consumer of `govuk_template` depending on a different behaviour of `js-hidden` that gets overridden.

Looking at [GOV.UK usage of `js-hidden`](https://github.com/search?p=3&q=js-hidden+repo%3Aalphagov%2Fbusiness-support-finder+repo%3Aalphagov%2Fcalculators+repo%3Aalphagov%2Fcalendars+repo%3Aalphagov%2Fcollections+repo%3Aalphagov%2Fcontacts-admin+repo%3Aalphagov%2Fcontacts-frontend+repo%3Aalphagov%2Fcourts-frontend+repo%3Aalphagov%2Femail-alert-frontend+repo%3Aalphagov%2Ffeedback+repo%3Aalphagov%2Ffinder-frontend+repo%3Aalphagov%2Ffrontend+repo%3Aalphagov%2Fgovernment-frontend+repo%3Aalphagov%2Fhomepage-frontend+repo%3Aalphagov%2Finfo-frontend+repo%3Aalphagov%2Flicence-finder+repo%3Aalphagov%2Fmanuals-frontend+repo%3Aalphagov%2Fsmart-answers+repo%3Aalphagov%2Fspecialist-frontend+repo%3Aalphagov%2Fwhitehall&ref=searchresults&type=Code&utf8=%E2%9C%93) it seems consistent, but I don't know about other consumers of the template, and we should consider that later in the release version and `CHANGELOG`.