### PR TITLE
Release version 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.17.0
+
+- Add CSS hook (`.js-hidden`) for hiding content when JS is enabled. Some apps
+  have an equivalent hook, which can be removed once upgraded to this version
+
 # 0.16.4
 
 - Fix publish the Jinja version of the template with a `package.json` for those

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.16.4"
+  VERSION = "0.17.0"
 end


### PR DESCRIPTION
Add CSS hook (`.js-hidden`) for hiding content when JS is enabled.

Some apps have an equivalent hook, which can be removed once upgraded to this version