### PR TITLE
Clean up and modernise govuk_template.html

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -15,7 +15,7 @@
     <link href="<%= asset_path "govuk-template-print.css" %>" media="print" rel="stylesheet" type="text/css" />
 
     <!--[if IE 8]>
-    <script type="text/javascript">
+    <script>
       (function(){if(window.opera){return;}
        setTimeout(function(){var a=document,g,b={families:(g=
        ["nta"]),urls:["<%= asset_path "fonts-ie8.css" %>"]},
@@ -32,7 +32,7 @@
 
 
     <!--[if lt IE 9]>
-      <script src="<%= asset_path "ie.js" %>" type="text/javascript"></script>
+      <script src="<%= asset_path "ie.js" %>"></script>
     <![endif]-->
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
@@ -49,7 +49,7 @@
   </head>
 
   <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>
-    <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
     <%= yield :body_start %>
 
@@ -117,7 +117,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <script src="<%= asset_path "govuk-template.js" %>" type="text/javascript"></script>
+    <script src="<%= asset_path "govuk-template.js" %>"></script>
 
     <%= yield :body_end %>
   </body>

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -4,14 +4,12 @@
 <!--[if gt IE 8]><!--><html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>"><!--<![endif]-->
   <head>
     <meta charset="utf-8" />
-
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
     <!--[if gt IE 8]><!--><link href="<%= asset_path "govuk-template.css" %>" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
     <!--[if IE 6]><link href="<%= asset_path "govuk-template-ie6.css" %>" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
     <!--[if IE 7]><link href="<%= asset_path "govuk-template-ie7.css" %>" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
     <!--[if IE 8]><link href="<%= asset_path "govuk-template-ie8.css" %>" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-
     <link href="<%= asset_path "govuk-template-print.css" %>" media="print" rel="stylesheet" type="text/css" />
 
     <!--[if IE 8]>
@@ -26,14 +24,8 @@
       })()
     </script>
     <![endif]-->
-    <!--[if gte IE 9]><!-->
-      <link href="<%= asset_path "fonts.css" %>" media="all" rel="stylesheet" type="text/css" />
-    <!--<![endif]-->
-
-
-    <!--[if lt IE 9]>
-      <script src="<%= asset_path "ie.js" %>"></script>
-    <![endif]-->
+    <!--[if gte IE 9]><!--><link href="<%= asset_path "fonts.css" %>" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+    <!--[if lt IE 9]><script src="<%= asset_path "ie.js" %>"></script><![endif]-->
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <link rel="mask-icon" href="<%= asset_path 'gov.uk_logotype_crown.svg' %>" color="#0b0c0c">

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -37,14 +37,9 @@
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <link rel="mask-icon" href="<%= asset_path 'gov.uk_logotype_crown.svg' %>" color="#0b0c0c">
-
-    <!-- Size for iPad and iPad mini (high resolution) -->
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="<%= asset_path "apple-touch-icon-152x152.png" %>">
-    <!-- Size for iPhone and iPod touch (high resolution) -->
     <link rel="apple-touch-icon-precomposed" sizes="120x120" href="<%= asset_path "apple-touch-icon-120x120.png" %>">
-    <!-- Size for iPad 2 and iPad mini (standard resolution) -->
     <link rel="apple-touch-icon-precomposed" sizes="76x76" href="<%= asset_path "apple-touch-icon-76x76.png" %>">
-    <!-- Default non-defined size, also used for Android 2.1+ devices -->
     <link rel="apple-touch-icon-precomposed" href="<%= asset_path "apple-touch-icon-60x60.png" %>">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,7 +66,6 @@
         <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
       <% end %>
     </div>
-    <!--end global-cookie-message-->
 
     <% unless @omit_header %>
     <header role="banner" id="global-header" class="<%= yield(:header_class) %>">
@@ -87,13 +81,11 @@
         <%= yield :proposition_header %>
       </div>
     </header>
-    <!--end header-->
     <% end %>
 
     <%= yield :after_header %>
 
     <div id="global-header-bar"></div>
-    <!--end global-header-bar-->
 
     <%= content_for?(:content) ? yield(:content) : yield %>
 
@@ -122,8 +114,6 @@
         </div>
       </div>
     </footer>
-
-    <!--end footer-->
 
     <div id="global-app-error" class="app-error hidden"></div>
 

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -3,7 +3,7 @@
 <!--[if lt IE 9]><html class="lte-ie8" lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>"><![endif]-->
 <!--[if gt IE 8]><!--><html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>"><!--<![endif]-->
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta charset="utf-8" />
 
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 


### PR DESCRIPTION
Use HTML5 preferred values.

Reduce page load by:
* removing HTML comments
* removing unnecessary script `type` attributes (https://www.w3.org/TR/html5/scripting-1.html#script)
* shortening charset declaration to HTML5 preferred value (https://www.w3.org/TR/html5/document-metadata.html#attr-meta-charset)

Also removes line breaks in the `<head>` tag and puts conditional comments onto a single line where appropriate. 