### PR TITLE
Migrate viewport declaration from govuk_frontend_toolkit

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -1,3 +1,11 @@
+@-ms-viewport {
+  width: device-width;
+}
+
+@-o-viewport {
+  width: device-width;
+}
+
 html, body, button, input, table, td, th { font-family: $NTA-Light; }
 
 // basic styles for HTML5 and other elements

--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -1,8 +1,5 @@
+// needed for IE10 desktop snap mode: http://menacingcloud.com/?c=cssViewportOrMetaTag
 @-ms-viewport {
-  width: device-width;
-}
-
-@-o-viewport {
   width: device-width;
 }
 


### PR DESCRIPTION
The viewport declarations for Opera and IE used to be defined in govuk_frontend_toolkit. It would be better if that was purely mixins and functions, and it makes sense that these declarations should live in the same place as the meta viewport declaration.

I looked into removing them completely, but there’s conflicting evidence as to what versions of Opera uses them, and at least IE10’s snap mode on desktop needs an @viewport.