### PR TITLE
Fix skiplink for Voiceover on iOS

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -64,7 +64,8 @@ a:focus {
 }
 
 .skiplink:focus {
-  position: static;
+  left: 0;
+  z-index: 1;
 }
 
 #skiplink-container {


### PR DESCRIPTION
Voiceover on iOS behaves weirdly with our main skiplink. It highlights it, which causes it to gain focus, and then it moves focus to a seemingly random other target. I've witnessed it within a few reloads select either a URL, or a paragraph item, or the Safari reload button, or a previously accessed browser tab.

@accessiblewebuk recorded an excellent video demonstrating this: https://youtu.be/-xL55PU9z40. The first reload will jump the focus back to the Safari reload button, while the second one will jump it to a link to "Log in to student finance." The only user interaction that is being performed in the video is the tapping of the reload button.

I've traced the root cause of this to be our implementation, which uses `position: static`. This causes the element to become part of the main page layout, which presumably confuses the screen reader's accessibility tree.

Switching to a normal `left: 0` positioning implementation seems to fix it. This causes the element to overlay the main logo in certain situations, but there aren't any other good positions that don't end up overlaying something like the search or navigation. It's worth mentioning (as pointed out by @dsingleton) that other websites such as github.com or webaim.org also take this approach.

### Before

<img width="347" alt="screen shot 2016-05-17 at 16 23 58" src="https://cloud.githubusercontent.com/assets/1650875/15328813/28612fc2-1c4e-11e6-859c-90b7a65f8c6f.png">

### After

<img width="426" alt="screen shot 2016-05-17 at 16 24 38" src="https://cloud.githubusercontent.com/assets/1650875/15328819/2e5d5964-1c4e-11e6-8dcc-b0186e4dc447.png">

### After (tablet and mobile)

<img width="300" alt="screen shot 2016-05-17 at 16 24 49" src="https://cloud.githubusercontent.com/assets/1650875/15328831/39d13cc0-1c4e-11e6-90c4-5bee6dd7efba.png">
