### PR TITLE
Version 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.17.2
+
+- Fix a bug with the skip-to-content link and iOS Voiceover
+- Migrate @viewport statement from govuk_frontend_toolkit
+
 # 0.17.1
 
 - Reduce file size of template: removes HTML comments, `type` attributes on

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.17.1"
+  VERSION = "0.17.2"
 end


### PR DESCRIPTION
- Fix a bug with the skip-to-content link and iOS Voiceover
- Migrate @viewport statement from govuk_frontend_toolkit