### PR TITLE
Use text-colour for headings in footer

### DIFF
--- a/source/assets/stylesheets/_footer.scss
+++ b/source/assets/stylesheets/_footer.scss
@@ -25,7 +25,7 @@
   h2 {
     @include core-24;
     font-weight: bold;
-    color: $footer-text;
+    color: $text-colour;
     margin: 0;
 
     a {


### PR DESCRIPTION
This used to be a custom grey variable set to `#0b0c0c` but was converted to `footer-text`, which made the headings too grey (see https://github.com/alphagov/govuk_template/pull/201)

Switch back to the darker colour to improve contrast, use $text-colour instead.

cc @gemmaleigh 

## Before
![screen shot 2016-05-26 at 15 10 19](https://cloud.githubusercontent.com/assets/319055/15580832/f6fc25b6-2361-11e6-8490-587a8f5ffa11.png)

## After
![screen shot 2016-05-26 at 15 10 47](https://cloud.githubusercontent.com/assets/319055/15580831/f6dc7d4c-2361-11e6-8120-a2efaac7542a.png)
