### PR TITLE
Add logo svg asset to precompile list - fixes rails error.

### DIFF
--- a/lib/govuk_template/engine.rb
+++ b/lib/govuk_template/engine.rb
@@ -13,6 +13,7 @@ module GovukTemplate
         apple-touch-icon-76x76.png
         gov.uk_logotype_crown_invert.png
         gov.uk_logotype_crown_invert_trans.png
+        gov.uk_logotype_crown.svg
         opengraph-image.png
       )
     end


### PR DESCRIPTION
Using the latest release of the gem I was getting this error with
a brand new rails app:

```
Sprockets::Rails::Helper::AssetNotPrecompiled at /
Asset was not declared to be precompiled in production.
Add `Rails.application.config.assets.precompile += %w( gov.uk_logotype_crown.svg )` to `config/initializers/assets.rb`
```

The crown SVG was added relatively recently, but not included in the
rails asset precompile list, so i've added it.

Curiously this wasn't a problem with GOV.UK's `static` applicaton,
which has the same version of the gem, but runs fine.

Regardless, i think any assets referenced should be part of the
precompile list, so it's worth adding here.