### PR TITLE
Add NPM publisher for jinja package

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -146,6 +146,15 @@ namespace :build do
       puts "Pushing govuk_template_ejs #{GovukTemplate::VERSION} to git repo"
       q.publish
     end
+
+    require 'publisher/jinja_publisher'
+    q = Publisher::JinjaPublisher.new
+    if q.version_released?
+      puts "govuk_template_jinja #{GovukTemplate::VERSION} already released. Not pushing."
+    else
+      puts "Pushing govuk_template_jinja #{GovukTemplate::VERSION} to git repo"
+      q.publish
+    end
   end
 end
 

--- a/build_tools/publisher/jinja_publisher.rb
+++ b/build_tools/publisher/jinja_publisher.rb
@@ -1,0 +1,43 @@
+require 'govuk_template/version'
+require 'tmpdir'
+require 'open3'
+
+module Publisher
+  class JinjaPublisher
+    GIT_URL = "git@github.com:alphagov/govuk_template_jinja"
+
+    def initialize(version = GovukTemplate::VERSION)
+      @version = version
+      @repo_root = Pathname.new(File.expand_path('../../..', __FILE__))
+      @source_dir = @repo_root.join('pkg', "jinja_govuk_template-#{@version}")
+    end
+
+    def publish
+      Dir.mktmpdir("govuk_template_jinja") do |dir|
+        run "git clone -q #{GIT_URL.shellescape} #{dir.shellescape}"
+        Dir.chdir(dir) do
+          run "ls -1 | grep -v 'README.md' | xargs -I {} rm -rf {}"
+          run "cp -r #{@source_dir.to_s.shellescape}/* ."
+          run "git add -A ."
+          run "git commit -q -m 'Publishing GOV.UK Jinja template version #{@version}'"
+          run "git tag v#{@version}"
+          run "git push --tags origin master"
+          run "npm publish ./"
+        end
+      end
+    end
+
+    def version_released?
+      output = run("git ls-remote --tags #{GIT_URL.shellescape}")
+      return !! output.match(/v#{@version}/)
+    end
+
+    private
+
+    def run(command)
+      output, status = Open3.capture2e(command)
+      abort "Error running #{command}: exit #{status.exitstatus}\n#{output}" if status.exitstatus > 0
+      output
+    end
+  end
+end


### PR DESCRIPTION
New repo created at http://github.com/alphagov/govuk_template_jinja and initially updated by running this code locally.

Follows the same pattern as other NPM published versions, like `mustache` and `ejs`. There's quite a bit of duplication in the publisher code, but this doesn't feel like the time to refactor it, partly as we're looking at what might replace `govuk_template` as part of the Patters and Tools team discovery.