### PR TITLE
Gem publisher

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 $:.unshift File.expand_path('../lib', __FILE__)
 $:.unshift File.expand_path('../build_tools', __FILE__)
 require "govuk_template/version"
-require "gem_publisher"
 
 desc "Compile template and assets from ./source into ./app"
 task :compile do

--- a/Rakefile
+++ b/Rakefile
@@ -95,20 +95,18 @@ namespace :build do
 
   desc "Build and release gem to gemfury if version has been updated"
   task :and_release_if_updated => :build do
-    p = GemPublisher::Publisher.new('govuk_template.gemspec')
-    if p.version_released?
-      puts "govuk_template-#{GovukTemplate::VERSION} already released.  Not pushing."
+    require 'publisher/gem_publisher'
+    q = Publisher::GemPublisher.new
+    if q.version_released?
+      puts "Github release v#{GovukTemplate::VERSION} already released. Not pushing."
     else
-      puts "Pushing govuk_template-#{GovukTemplate::VERSION} to gemfury"
-      p.pusher.push "pkg/govuk_template-#{GovukTemplate::VERSION}.gem", :rubygems
-      p.git_remote.add_tag "v#{GovukTemplate::VERSION}"
-      puts "Done."
+      puts "Pushing Github release v#{GovukTemplate::VERSION} to ruby gems"
+      q.publish
 
       require 'publisher/docs_publisher'
       q = Publisher::DocsPublisher.new
       puts "Pushing docs #{GovukTemplate::VERSION} to git repo"
       q.publish
-      puts "Done."
     end
 
     require 'publisher/release_publisher'

--- a/Rakefile
+++ b/Rakefile
@@ -95,12 +95,13 @@ namespace :build do
 
   desc "Build and release gem to gemfury if version has been updated"
   task :and_release_if_updated => :build do
-    require 'publisher/gem_publisher'
-    q = Publisher::GemPublisher.new
+
+    require 'publisher/release_publisher'
+    q = Publisher::ReleasePublisher.new
     if q.version_released?
       puts "Github release v#{GovukTemplate::VERSION} already released. Not pushing."
     else
-      puts "Pushing Github release v#{GovukTemplate::VERSION} to ruby gems"
+      puts "Pushing Github release v#{GovukTemplate::VERSION}"
       q.publish
 
       require 'publisher/docs_publisher'
@@ -109,12 +110,12 @@ namespace :build do
       q.publish
     end
 
-    require 'publisher/release_publisher'
-    q = Publisher::ReleasePublisher.new
+    require 'publisher/gem_publisher'
+    q = Publisher::GemPublisher.new
     if q.version_released?
       puts "Github release v#{GovukTemplate::VERSION} already released. Not pushing."
     else
-      puts "Pushing Github release v#{GovukTemplate::VERSION}"
+      puts "Pushing Github release v#{GovukTemplate::VERSION} to ruby gems"
       q.publish
     end
 

--- a/build_tools/packager/gem_packager.rb
+++ b/build_tools/packager/gem_packager.rb
@@ -1,3 +1,5 @@
+require 'gem_publisher'
+
 module Packager
   class GemPackager
     def self.build

--- a/build_tools/publisher/gem_publisher.rb
+++ b/build_tools/publisher/gem_publisher.rb
@@ -1,3 +1,4 @@
+require 'gem_publisher'
 require 'govuk_template/version'
 
 module Publisher

--- a/build_tools/publisher/gem_publisher.rb
+++ b/build_tools/publisher/gem_publisher.rb
@@ -1,0 +1,21 @@
+require 'govuk_template/version'
+
+module Publisher
+  class GemPublisher
+    def initialize(version = GovukTemplate::VERSION)
+      @version = version
+      @publisher = ::GemPublisher::Publisher.new('govuk_template.gemspec')
+      @repo_root = Pathname.new(File.expand_path('../../..', __FILE__))
+      @source_file = @repo_root.join('pkg', "pkg/govuk_template-#{@version}.gem")
+    end
+
+    def publish
+      @publisher.pusher.push(@source_file, :rubygems)
+      @publisher.git_remote.add_tag("v#{@version}")
+    end
+
+    def version_released?
+      @publisher.version_released?
+    end
+  end
+end


### PR DESCRIPTION
This repo is natively a gem, and the other publishers are treated as derivatives of that. Long term we want `govuk_template` to be more language/package agnostic and built to support many build outputs, where `gem` is just one of them.

Treating the gem publishing in the same way as other types is a small step towards that. Also couples docs publication to the repo release step, rather than the gem.