### PR TITLE
Version 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.18.0
+
+- Publish the Jinja version of the template to NPM
+- Update HTML5 Shiv to the latest version
+- Remove an errant font loader script that was only being used for IE8
+
 # 0.17.3
 
 - Fix colour of H2 headings in footer

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.17.3"
+  VERSION = "0.18.0"
 end


### PR DESCRIPTION
- Publish the Jinja version of the template to NPM
- Update HTML5 Shiv to the latest version
- Remove an errant font loader script that was only being used for IE8