### PR TITLE
Remove external link styles

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -94,19 +94,6 @@ a:active {
   color: $link-active-colour;
 }
 
-a[rel="external"] {
-  @include external-link-default;
-  @include external-link-16;
-  @include media(tablet) {
-    @include external-link-19;
-  }
-}
-
-.external-link {
-  @include external-link-12-no-hover;
-  @include external-link-heading;
-}
-
 // adjustments to normalize.css
 
 /*


### PR DESCRIPTION
[govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit) is [potentially removing external link styles](https://github.com/alphagov/govuk_frontend_toolkit/pull/293). If that happens then we’ll want to remove them from govuk_template as well.