### PR TITLE
Remove generated gov.uk from relative print links

### DIFF
--- a/source/assets/stylesheets/_core-print.scss
+++ b/source/assets/stylesheets/_core-print.scss
@@ -20,11 +20,7 @@ a, a:visited {
   word-wrap: break-word;
 }
 
-a[href^="/"]:after {
-  content: " (https://www.gov.uk" attr(href) ")";
-  font-size: 90%;
-}
-
+a[href^="/"]:after,
 a[href^="http://"]:after,
 a[href^="https://"]:after {
   content: " (" attr(href) ")";


### PR DESCRIPTION
Relative links currently have a `https://www.gov.uk` [prepended to them in the print view](https://github.com/alphagov/govuk_template/blob/0704a5ec0bab9b74aae93ac70bce95f8e4a280b5/source/assets/stylesheets/_core-print.scss#L23). This is fine for gov.uk but not for other consumers of the template. I’ve [updated static to include the prefix](https://github.com/alphagov/static/pull/823); this commit removes it from the template. Will fix https://github.com/alphagov/govuk_template/issues/224.