### PR TITLE
Remove color within link attribute

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -17,7 +17,7 @@
     <!--[if lt IE 9]><script src="<%= asset_path "ie.js" %>"></script><![endif]-->
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
-    <link rel="mask-icon" href="<%= asset_path 'gov.uk_logotype_crown.svg' %>" color="#0b0c0c">
+    <link rel="mask-icon" href="<%= asset_path 'gov.uk_logotype_crown.svg' %>" >
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="<%= asset_path "apple-touch-icon-152x152.png" %>">
     <link rel="apple-touch-icon-precomposed" sizes="120x120" href="<%= asset_path "apple-touch-icon-120x120.png" %>">
     <link rel="apple-touch-icon-precomposed" sizes="76x76" href="<%= asset_path "apple-touch-icon-76x76.png" %>">


### PR DESCRIPTION
In accessability testing it was flagged that a color attribute was within a <link> attribute which is against the W3 HTML guidelines: https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.gov.uk%2F

This was added in commit 0d300da1bdc470527a35a3501037672974741505 along with other changes but without explanation about why the color part was added specifically.

Removing this on an HTML page doesn't *seem* to make any significant changes to the template.

Note: haven't been able to test this locally on dev VM so would be interested to see how this is tested, if required.

/cc @emmabeynon @klssmith @davidbasalla 