### PR TITLE
Add a table of template blocks to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Ruby language (1.9.3+), the build tool [Rake](http://rake.rubyforge.org/) & 
 
 ## Usage
 
+* [GOV.UK template blocks and their default values (how to customise the template)](docs/template-blocks.md)
 * [Setting a Skip link](docs/usage.md#skip-link)
 * [Propositional title and navigation](docs/usage.md#propositional-title-and-navigation)
 

--- a/docs/template-blocks.md
+++ b/docs/template-blocks.md
@@ -1,0 +1,25 @@
+## GOV.UK template blocks and their default values
+
+| Template block name       |  Location / Information                         |   Default template values
+|---                        |---                                              |---
+| top_of page               | Before doctype                                  | Insertion point
+| html_lang                 | value of the HTML lang attribute                | en
+| page_title                | Text inside the `<title>` element               | GOV.UK - The best place to find government services and information
+| head                      | Before closing `</head>` element                | Insertion point
+| body_classes              | Classes to be added to the `<body>` element     | Insertion point
+| body_start                | After opening `<body>` element                  | Insertion point
+| skip_link_message         | After `body_start` block                        | Skip to main content
+| cookie_message            | After `#skiplink-container` div                 | `<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>`
+| header_class              | `<header>` element                              | Set the value of header_class to [with-proposition](docs/usage.md#propositional-title-and-navigation) to show the propositional navigation
+| homepage_url              | URL of anchor element wrapping logo             | https://www.gov.uk/
+| logo_link_title           | Title of anchor element wrapping logo           | Go to the GOV.UK homepage
+| global_header_text        | Text next to the crown image                    | GOV.UK
+| inside_header             | Inside parent `.header-global`                  | Insertion point
+| proposition_header        | Inside parent `.header-wrapper`                 | Insertion point
+| after_header              | After closing `</header>` element               | Insertion point
+| content                   | After `#global-header-bar`                      | Insertion point
+| footer_top                | Inside parent `#footer-wrapper`                 | Insertion point
+| footer_support_links      | Inside parent `.footer-meta-inner`              | Insertion point
+| licence_message           | Inside parent `.open-government-licence`        | `<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>`
+| crown_copyright_message   | Inside parent `.copyright`                      | © Crown copyright
+| body_end                  | Before closing `</body>` element                | Insertion point

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,9 @@
 # Usage
 
+## To customise the GOV.UK template
+
+Refer to the table of [template blocks](./docs/template-blocks.md) and their default values.
+
 ## Skip link
 
 The [govuk_template sets a skip link](https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb#L64-L68) to `#content`, but doesn't provide an element with `id="content"`. You'll need to add `id="content"` to your main content area, to ensure the skip link will work.


### PR DESCRIPTION
This PR adds a table to show how the govuk_template can be customised.

There are a list of:
- template regions which can be customised - as insertion points and their location in the template
- the default values which can be overridden

