### PR TITLE
Version 0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.2
+
+- Degrade gracefully when external JS can’t be loaded ([PR #248](https://github.com/alphagov/govuk_template/pull/248))
+
 # 0.18.1
 
 - Remove gov.uk prefix from relative links when printing ([PR #234](https://github.com/alphagov/govuk_template/pull/234))

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.18.1"
+  VERSION = "0.18.2"
 end


### PR DESCRIPTION
- Degrade gracefully when external JS can’t be loaded ([PR #248](https://github.com/alphagov/govuk_template/pull/248))