### PR TITLE
Add docs for adding tabindex="-1" to fix the skiplink

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,6 +8,13 @@ Refer to the table of [template blocks](./docs/template-blocks.md) and their def
 
 The [govuk_template sets a skip link](https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb#L64-L68) to `#content`, but doesn't provide an element with `id="content"`. You'll need to add `id="content"` to your main content area, to ensure the skip link will work.
 
+    <main id="content" role="main" tabindex="-1">
+
+It is recommended to use the main element, with a role of main (to support older assistive technology), also `tabindex="-1"` is required to fix the issue [with focus in Safari](https://bugs.chromium.org/p/chromium/issues/detail?id=37721).
+
+You can see an [example of this working in GOV.UK elements](https://github.com/alphagov/govuk_elements/blob/master/app/views/index.html#L9).
+
+
 ## Propositional title and navigation
 
 You can get a propositional title and navigation by setting the content for `header_class` to `with-proposition` and `proposition_header` in the form:


### PR DESCRIPTION
The GOV.UK template sets a skiplink to `#content` (just tab on any
GOV.UK page and hit ENTER when "Skip to main content" is highlighted).

This allows users to navigate to the main content area using only the
keyboard. Pressing enter when focus is on the skiplink should then set
focus on the #content area.

In Safari, there's a bug where this doesn't happen unless
`tabindex="-1"` is set on the destination element (in this case `<main
id="content">`). 

Here's the [bug report](https://bugs.webkit.org/show_bug.cgi?id=141113).

This pull request adds documentation for adding `tabindex="-1"` 
to the `<main>` element to fix this issue.
