### PR TITLE
v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.19.0
+
+- Remove external link styles ([PR #231](https://github.com/alphagov/govuk_template/pull/231))
+- Remove extraneous copy of HTML5shiv that wasn’t being used ([PR #254](https://github.com/alphagov/govuk_template/pull/254))
+- Update govuk_frontend_toolkit to latest version ([PR #256](https://github.com/alphagov/govuk_template/pull/256))
+
 # 0.18.3
 
 - Add docs for adding `tabindex="-1"` to fix the skiplink ([PR #250](https://github.com/alphagov/govuk_template/pull/250))

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.18.3"
+  VERSION = "0.19.0"
 end


### PR DESCRIPTION
- Remove external link styles ([PR #231](https://github.com/alphagov/govuk_template/pull/231))
- Remove extraneous copy of HTML5shiv that wasn’t being used ([PR #254](https://github.com/alphagov/govuk_template/pull/254))
- Update govuk_frontend_toolkit to latest version ([PR #256](https://github.com/alphagov/govuk_template/pull/256))
