### PR TITLE
Have focus outline appear outside of element rather than covering it.

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -91,13 +91,19 @@ a:focus {
 input:focus,
 textarea:focus,
 select:focus,
-button:focus,
-#global-header input:focus {
+button:focus {
   outline: 3px solid $focus-colour;
   outline-offset: 0;
 }
 
 #global-header {
+
+  input[type=search]:focus {
+    outline: 3px solid $focus-colour;
+    /* Focus appears inside the input */
+    outline-offset: -3px;
+  }
+
   h1 a:focus {
     background-color: transparent;
     outline: none;

--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -94,6 +94,7 @@ select:focus,
 button:focus,
 #global-header input:focus {
   outline: 3px solid $focus-colour;
+  outline-offset: 0;
 }
 
 #global-header {

--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -101,7 +101,7 @@ button:focus {
   input[type=search]:focus {
     outline: 3px solid $focus-colour;
     /* Focus appears inside the input */
-    outline-offset: -3px;
+    outline-offset: -2px;
   }
 
   h1 a:focus {


### PR DESCRIPTION
This PR adds a 0 offset to focus outlines. This works around a bug in Chrome and Safari where focus is drawn over an element rather than around it.

Before:
![screen shot 2016-10-26 at 18 00 03](https://cloud.githubusercontent.com/assets/2204224/19736294/9984ecd4-9ba6-11e6-92de-f0e642965388.png)
![screen shot 2016-10-26 at 18 00 27](https://cloud.githubusercontent.com/assets/2204224/19736296/9e5fdab6-9ba6-11e6-8783-d09bd2d9172f.png)

After:
![screen shot 2016-10-26 at 18 00 10](https://cloud.githubusercontent.com/assets/2204224/19736305/a2e658b2-9ba6-11e6-8e17-a7cad70cf5c3.png)
![screen shot 2016-10-26 at 18 00 36](https://cloud.githubusercontent.com/assets/2204224/19736314/a89f9c32-9ba6-11e6-8300-63b8f260f763.png)

I've not tested it directly (don't know how to run template), but have made the same changes in browser to test. Does not seem to impact on buttons.
