### PR TITLE
Skiplink colour contrast

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -65,6 +65,12 @@ a:focus {
 .skiplink {
   position: absolute;
   left: -9999em;
+
+  /* Default link colour doesn't have enough contrast against $focus-colour */
+  &:focus, 
+  &:visited {
+    color: $text-colour;
+  }
 }
 
 .skiplink:focus {


### PR DESCRIPTION
Skiplink has the default link colour, which kept failing against $focus-colour
background. Making the link colour $black for :focus and :visited states.