### PR TITLE
Improve contrast of links when focused

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -60,6 +60,11 @@ a:focus {
   outline: 3px solid $focus-colour;
 }
 
+/* Make links slightly darker when focused to improve contrast. */
+a:link:focus {
+  color: darken( $link-colour, 2.5%)
+}
+
 /* Make skiplinks visible when they are tabbed to */
 
 .skiplink {


### PR DESCRIPTION
Fixes #264 

- Makes link text slightly darker when focused - now hits 1:4.5 contrast against yellow.

Note - I've not tested this with template itself, but the sass itself seems to work.

## Before:
![screen shot 2017-01-30 at 13 08 42-normal](https://cloud.githubusercontent.com/assets/2204224/22424181/52737ada-e6ed-11e6-8632-e36c4fb61a96.png)

## After:
![screen shot 2017-01-30 at 13 09 03-darker](https://cloud.githubusercontent.com/assets/2204224/22424188/56b90e70-e6ed-11e6-9d04-6c1cc731407a.png)

