### PR TITLE
Make header text colour black when focused

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -67,7 +67,7 @@ a:focus {
   left: -9999em;
 
   /* Default link colour doesn't have enough contrast against $focus-colour */
-  &:focus, 
+  &:focus,
   &:visited {
     color: $text-colour;
   }

--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -114,6 +114,9 @@
     a#proposition-name:hover {
       text-decoration: underline;
     }
+    a#proposition-name:focus {
+      color: $text-colour;
+    }
     a.menu {
       @include core-16;
       color: $white;


### PR DESCRIPTION
The header text has poor contrast when focused as it's white on yellow. This PR changes it to black on yellow to match other anchors on the page.

Also changes to use `$text-colour` from black, which felt more consistent.

Before:
![screen shot 2017-01-30 at 13 04 42](https://cloud.githubusercontent.com/assets/2204224/22427475/3a558fb6-e6fb-11e6-9d10-df0dcb37151a.png)
After:
![screen shot 2017-01-30 at 13 04 16](https://cloud.githubusercontent.com/assets/2204224/22427478/41f2d12a-e6fb-11e6-83b5-3b35d7064c96.png)

