### PR TITLE
Allow skiplink target to be overridden

### DIFF
--- a/build_tools/compiler/django_processor.rb
+++ b/build_tools/compiler/django_processor.rb
@@ -31,6 +31,7 @@ module Compiler
       proposition_header:   block_for(:proposition_header),
       top_of_page:          "{% load staticfiles %}" + block_for(:top_of_page),
       skip_link_message:    statement_tag_for(:skip_link_message, 'Skip to main content'),
+      skip_link_target:     statement_tag_for(:skip_link_target, 'content'),
       logo_link_title:      statement_tag_for(:logo_link_title, 'Go to the GOV.UK homepage'),
       licence_message:      block_for(:licence_message, '<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>'),
       crown_copyright_message: statement_tag_for(:crown_copyright_message, '&copy; Crown copyright'),

--- a/build_tools/compiler/ejs_processor.rb
+++ b/build_tools/compiler/ejs_processor.rb
@@ -27,6 +27,7 @@ module Compiler
       proposition_header:   partial_for(:proposition_header),
       top_of_page:          partial_for(:top_of_page),
       skip_link_message:    "<% if (skipLinkMessage) { %><%= skipLinkMessage %><% } else { %>Skip to main content<% } %>",
+      skip_link_target:     "<% if (skipLinkTarget) { %><%= skipLinkTarget %><% } else { %>content<% } %>",
       logo_link_title:      "<% if (logoLinkTitle) { %><%= logoLinkTitle %><% } else { %>Go to the GOV.UK homepage<% } %>",
       licence_message:      partial_for(:licence_message),
       crown_copyright_message: "<% if (crownCopyrightMessage) { %><%= crownCopyrightMessage %><% } else { %>&copy; Crown copyright<% } %>",

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -35,6 +35,7 @@ module Compiler
       proposition_header:   block_for(:proposition_header),
       top_of_page:          block_for(:top_of_page),
       skip_link_message:    statement_tag_for(:skip_link_message, 'Skip to main content'),
+      skip_link_target:     statement_tag_for(:skip_link_target, 'content'),
       logo_link_title:      statement_tag_for(:logo_link_title, 'Go to the GOV.UK homepage'),
       licence_message:      block_for(:licence_message, '<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>'),
       crown_copyright_message: unescaped_statement_tag_for(:crown_copyright_message, '&copy; Crown copyright'),

--- a/build_tools/compiler/liquid_processor.rb
+++ b/build_tools/compiler/liquid_processor.rb
@@ -27,6 +27,7 @@ module Compiler
       proposition_header:   include_for(:proposition_header),
       top_of_page:          include_for(:top_of_page),
       skip_link_message:    "{% if page.skip_link_message %}{{ page.skip_link_message }}{% else %}Skip to main content{% endif %}",
+      skip_link_target:     "{% if page.skip_link_target %}{{ page.skip_link_target }}{% else %}content{% endif %}",
       logo_link_title:      "{% if page.logo_link_title %}{{ page.logo_link_title }}{% else %}Go to the GOV.UK homepage{% endif %}",
       licence_message:      include_for(:licence_message),
       crown_copyright_message: "{% if page.crown_copyright_message %}{{ page.crown_copyright_message }}{% else %}&copy; Crown copyright{% endif %}",

--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -27,6 +27,7 @@ module Compiler
       proposition_header:   tag_for(:propositionHeader),
       top_of_page:          tag_for(:topOfPage),
       skip_link_message:    tag_for(:skipLinkMessage, 'Skip to main content'),
+      skip_link_target:     tag_for(:skipLinkTarget, 'content'),
       logo_link_title:      tag_for(:logoLinkTitle, 'Go to the GOV.UK homepage'),
       licence_message:      tag_for(:licenceMessage, '<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>'),
       crown_copyright_message: tag_for(:crownCopyrightMessage, '&copy; Crown copyright'),

--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -31,6 +31,7 @@ module Compiler
       proposition_header:   unescaped_html_tag_for(:propositionHeader),
       top_of_page:          unescaped_html_tag_for(:topOfPage),
       skip_link_message:    tag_for(:skipLinkMessage),
+      skip_link_target:     tag_for(:skipLinkTarget),
       logo_link_title:      tag_for(:logoLinkTitle),
       licence_message:      unescaped_html_tag_for(:licenceMessage),
       crown_copyright_message: tag_for(:crownCopyrightMessage),

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -12,7 +12,7 @@ module Compiler
       # top_of_page has a special purpose: it is required by Play to define the
       # parameters to pass when rendering
       # https://www.playframework.com/documentation/2.2.x/ScalaTemplates#Template-parameters
-      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = HtmlFormat.empty, propositionHeader:Html = HtmlFormat.empty, homepageUrl:Option[Html] = None, globalHeaderText:Option[Html] = None, cookieMessage: Option[Html] = None, skipLinkMessage:Option[Html], logoLinkTitle:Option[Html] = None, licenceMessage:Html, crownCopyrightMessage:Option[Html])(content:Html)',
+      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = HtmlFormat.empty, propositionHeader:Html = HtmlFormat.empty, homepageUrl:Option[Html] = None, globalHeaderText:Option[Html] = None, cookieMessage: Option[Html] = None, skipLinkMessage:Option[Html], skipLinkTarget:Option[Html], logoLinkTitle:Option[Html] = None, licenceMessage:Html, crownCopyrightMessage:Option[Html])(content:Html)',
       head: '@head',
       body_classes: '@bodyClasses.getOrElse("")',
       header_class: '@headerClass',
@@ -28,6 +28,7 @@ module Compiler
       global_header_text: '@globalHeaderText.getOrElse("GOV.UK")',
       cookie_message: '@cookieMessage.getOrElse("<p>GOV.UK uses cookies to make the site simpler. <a href=\"https://www.gov.uk/help/cookies\">Find out more about cookies</a></p>")',
       skip_link_message: '@skipLinkMessage.getOrElse("Skip to main content")',
+      skip_link_target: '@skipLinkTarget.getOrElse("content")',
       logo_link_title: '@logoLinkTitle.getOrElse("Go to the GOV.UK homepage")',
       licence_message: '@licenceMessage',
       crown_copyright_message: '@crownCopyrightMessage.getOrElse("&copy; Crown copyright")',

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,9 @@ It is recommended to use the main element, with a role of main (to support older
 
 You can see an [example of this working in GOV.UK elements](https://github.com/alphagov/govuk_elements/blob/master/app/views/index.html#L9).
 
+If you need to link to an `id` other than `content`, you can override it
+by setting `skip_link_target`.
+
 
 ## Propositional title and navigation
 

--- a/integration_tests/html_rendered_by_each_integration_testing_app_spec.rb
+++ b/integration_tests/html_rendered_by_each_integration_testing_app_spec.rb
@@ -88,6 +88,10 @@ describe "HTML rendered by each integration testing app" do
         expect(subject).to have_tag("#skiplink-container", text: "Custom skip link text")
       end
 
+      it "should support a skip_link_target" do
+        expect(subject).to have_tag("#skiplink-container a", with: { href: "#custom" })
+      end
+
       it "should support a logo_link_title" do
         expect(subject).to have_tag(".header-logo a", with: { title: "Custom logo link title text" })
       end

--- a/integration_tests/integrations/django/build.py
+++ b/integration_tests/integrations/django/build.py
@@ -16,6 +16,7 @@ django.setup()
 context = {
     "html_lang": "rb",
     "skip_link_message": "Custom skip link text",
+    "skip_link_target": "custom",
     "logo_link_title": "Custom logo link title text",
     "crown_copyright_message": "Custom crown copyright message text",
 }

--- a/integration_tests/integrations/django/build.sh
+++ b/integration_tests/integrations/django/build.sh
@@ -9,7 +9,7 @@ mkdir -p vendor/django_govuk_template
 # TODO: Pick the latest, not every matching tgz file!
 tar -zxf ../../../pkg/django_govuk_template-*.tgz -C vendor/django_govuk_template --strip-components 1
 
-# --user param allows installing without sudo: 
+# --user param allows installing without sudo:
 pip install virtualenv --user
 virtualenv .env
 source .env/bin/activate

--- a/integration_tests/integrations/jinja/build.py
+++ b/integration_tests/integrations/jinja/build.py
@@ -8,6 +8,7 @@ template = env.get_template('test_template.html')
 content = template.render({
     "html_lang": "rb",
     "skip_link_message": "Custom skip link text",
+    "skip_link_target": "custom",
     "logo_link_title": "Custom logo link title text",
     "crown_copyright_message": "Custom crown copyright message text",
 })

--- a/integration_tests/integrations/nunjucks/build.js
+++ b/integration_tests/integrations/nunjucks/build.js
@@ -13,6 +13,7 @@ fs.writeFileSync(
   env.render('test_template.html', {
       'html_lang': 'rb',
       'skip_link_message': 'Custom skip link text',
+      'skip_link_target': 'custom',
       'logo_link_title': 'Custom logo link title text',
       'crown_copyright_message': 'Custom crown copyright message text',
   }),

--- a/integration_tests/integrations/rails/views/show.html.erb
+++ b/integration_tests/integrations/rails/views/show.html.erb
@@ -28,6 +28,8 @@ The page content
 
 <% content_for(:skip_link_message, "Custom skip link text") %>
 
+<% content_for(:skip_link_target, "custom") %>
+
 <% content_for(:logo_link_title, "Custom logo link title text") %>
 
 <% content_for(:licence_message, "Custom license message text") %>

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -36,7 +36,7 @@
 
     <div id="skiplink-container">
       <div>
-        <a href="#content" class="skiplink"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : "Skip to main content" %></a>
+        <a href="#<%= content_for?(:skip_link_target) ? yield(:skip_link_target) : "content" %>" class="skiplink"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : "Skip to main content" %></a>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #271

---

GOV.UK Template hardcodes the skiplink to point at `#content`. But sometimes using `#content` introduces unwanted styling from 3rd parties (eg [in GOV.UK Elements](https://github.com/alphagov/govuk_elements/blob/d6226bd2c8c7e256f995c0f519daaa4035c6bd54/public/sass/elements/_layout.scss#L9-L20)).

This commit allows users of the template to set their own target for the skiplink. They will still need to include the target element in their pages, same as they have to for `id='content'` at the moment.