### PR TITLE
[Discuss] Add text-decoration-skip: ink to all links on GOV.UK

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -80,6 +80,7 @@ fieldset {
 
 a:link {
   color: $link-colour;
+  text-decoration-skip: ink;
 }
 
 a:visited {


### PR DESCRIPTION
Based on some design updates Mia Allers has made, will work in Chrome Canary soon in Chrome Stable and Safari.

[This prevents underlines from being drawn too close to glyphs](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip)

![](https://cloud.githubusercontent.com/assets/2445413/23865489/cedd920e-080d-11e7-8290-308497c2b2fe.png)

http://caniuse.com/#feat=text-decoration

I've included the `-webkit-` prefix but having trouble as it seems like some Safari versions already skip the underline, need to investigate more...

Edit: I've had a look and it seems Safari does this behaviour by default.

Be good to get some feedback on edge cases people can think where we would not want to do this globally.


| Before | After |
|--------|------|
|![](https://cloud.githubusercontent.com/assets/2445413/23865385/742c1d4e-080d-11e7-8df6-c804fd375104.png)|![](https://cloud.githubusercontent.com/assets/2445413/23865415/89283b56-080d-11e7-8b3b-efde6041a361.png)|
| | |
|![](https://cloud.githubusercontent.com/assets/2445413/23865429/934415e2-080d-11e7-96f0-0f7d9fdd4e85.png)|![](https://cloud.githubusercontent.com/assets/2445413/23865439/997661a4-080d-11e7-8244-c176129ae02d.png)|
| | |
|![](https://cloud.githubusercontent.com/assets/2445413/23865362/5e2c8646-080d-11e7-8795-a81c0acae40f.png)|![](https://cloud.githubusercontent.com/assets/2445413/23865374/6638491a-080d-11e7-8920-c0a0f321989d.png)|


| Before | After |
|--------|------|
|![](https://cloud.githubusercontent.com/assets/2445413/23802852/885247b6-05ac-11e7-8edd-c4eff6882450.png)|![screencapture-gov-uk-social-security-child-support-tribunal-1489161673155](https://cloud.githubusercontent.com/assets/2445413/23802861/900471a0-05ac-11e7-82f3-29ab55f22f8d.png) |
| | |
|![](https://cloud.githubusercontent.com/assets/2445413/23802921/c849ed56-05ac-11e7-9cbc-425509caa396.png)|![screencapture-gov-uk-1489161620081](https://cloud.githubusercontent.com/assets/2445413/23802924/cac0e044-05ac-11e7-8d1f-8cf71a75467d.png)|
| | |
|![](https://cloud.githubusercontent.com/assets/2445413/23802950/e1685b92-05ac-11e7-942f-8aa457fe6305.png)|![](https://cloud.githubusercontent.com/assets/2445413/23802960/e581db40-05ac-11e7-94f5-c9debad0e5ca.png)|




