### PR TITLE
Version 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.20.0
+
+- Fix EJS template ([PR #270](https://github.com/alphagov/govuk_template/pull/270))
+- Add `theme-color` support to make the page surround in Chrome’s tab view on Android match the black GOV.UK header ([PR #278](https://github.com/alphagov/govuk_template/pull/278))
+- Add `text-decoration-skip: ink` to all links on GOV.UK ([PR #281](https://github.com/alphagov/govuk_template/pull/281))
+- Improve contrast of links when focused ([PR #272](https://github.com/alphagov/govuk_template/pull/272))
+- Make header text colour black when focused ([PR #274](https://github.com/alphagov/govuk_template/pull/274))
+
 # 0.19.2
 
 - Increase skiplink colour contrast ([PR #263](https://github.com/alphagov/govuk_template/pull/263))

--- a/govuk_template.gemspec
+++ b/govuk_template.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'sprockets', '2.10.0'
   spec.add_development_dependency 'sass', '3.2.9'
-  spec.add_development_dependency 'govuk_frontend_toolkit', '5.0.0'
+  spec.add_development_dependency 'govuk_frontend_toolkit', '5.2.0'
   spec.add_development_dependency 'gem_publisher', '1.3.0'
   spec.add_development_dependency 'rspec', '3.5.0'
   spec.add_development_dependency 'rspec-html-matchers', '0.8.1'

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.19.2"
+  VERSION = "0.20.0"
 end


### PR DESCRIPTION
- Fix EJS template ([PR #270](https://github.com/alphagov/govuk_template/pull/270))
- Add `theme-color` support to make the page surround in Chrome’s tab view on Android match the black GOV.UK header ([PR #278](https://github.com/alphagov/govuk_template/pull/278))
- Add `text-decoration-skip: ink` to all links on GOV.UK ([PR #281](https://github.com/alphagov/govuk_template/pull/281))
- Improve contrast of links when focused ([PR #272](https://github.com/alphagov/govuk_template/pull/272))
- Make header text colour black when focused ([PR #274](https://github.com/alphagov/govuk_template/pull/274))