### PR TITLE
Add block variable for body attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can [view a collection of auto-generated examples](http://alphagov.github.io
 
 ## Requirements
 
-The Ruby language (1.9.3+), the build tool [Rake](http://rake.rubyforge.org/) & the dependancy management tool [Bundler](http://bundler.io/)
+The Ruby language (1.9.3+), the build tool [Rake](http://rake.rubyforge.org/), the dependency management tool [Bundler](http://bundler.io/) & [Java](https://www.java.com/en/) 
 
 ## Detailed Docs
 

--- a/build_tools/compiler/django_processor.rb
+++ b/build_tools/compiler/django_processor.rb
@@ -15,6 +15,7 @@ module Compiler
     @@yield_hash = {
       after_header:         block_for(:after_header),
       body_classes:         block_for(:body_classes),
+      body_attributes:      block_for(:body_attributes),
       body_start:           block_for(:body_start),
       body_end:             block_for(:body_end),
       content:              block_for(:content),

--- a/build_tools/compiler/ejs_processor.rb
+++ b/build_tools/compiler/ejs_processor.rb
@@ -11,6 +11,7 @@ module Compiler
     @@yield_hash = {
       after_header:         partial_for(:after_header),
       body_classes:         "<%= bodyClasses %>",
+      body_attributes:      "<%= bodyAttributes %>",
       body_start:           partial_for(:body_start),
       body_end:             partial_for(:body_end),
       content:              partial_for(:content),

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -19,6 +19,7 @@ module Compiler
     @@yield_hash = {
       after_header:         block_for(:after_header),
       body_classes:         block_for(:body_classes),
+      body_attributes:      block_for(:body_attributes),
       body_start:           block_for(:body_start),
       body_end:             block_for(:body_end),
       content:              block_for(:content),

--- a/build_tools/compiler/liquid_processor.rb
+++ b/build_tools/compiler/liquid_processor.rb
@@ -11,6 +11,7 @@ module Compiler
     @@yield_hash = {
       after_header:         include_for(:after_header),
       body_classes:         include_for(:body_classes),
+      body_attributes:      include_for(:body_attributes),
       body_start:           include_for(:body_start),
       body_end:             include_for(:body), # Note that this differs from the key!
       content:              "{{ content }}",

--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -11,6 +11,7 @@ module Compiler
     @@yield_hash = {
       after_header:         tag_for(:afterHeader),
       body_classes:         tag_for(:bodyClasses),
+      body_attributes:      tag_for(:bodyAttributes),
       body_start:           tag_for(:bodyStart),
       body_end:             tag_for(:bodyEnd),
       content:              tag_for(:content),

--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -15,6 +15,7 @@ module Compiler
     @@yield_hash = {
       after_header:         unescaped_html_tag_for(:afterHeader),
       body_classes:         tag_for(:bodyClasses),
+      body_attributes:      unescaped_html_tag_for(:bodyAttributes),
       body_start:           unescaped_html_tag_for(:bodyStart),
       body_end:             unescaped_html_tag_for(:bodyEnd),
       content:              unescaped_html_tag_for(:content),

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -12,9 +12,10 @@ module Compiler
       # top_of_page has a special purpose: it is required by Play to define the
       # parameters to pass when rendering
       # https://www.playframework.com/documentation/2.2.x/ScalaTemplates#Template-parameters
-      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = HtmlFormat.empty, propositionHeader:Html = HtmlFormat.empty, homepageUrl:Option[Html] = None, globalHeaderText:Option[Html] = None, cookieMessage: Option[Html] = None, skipLinkMessage:Option[Html], logoLinkTitle:Option[Html] = None, licenceMessage:Html, crownCopyrightMessage:Option[Html])(content:Html)',
+      top_of_page: '@(title: Option[String], bodyClasses: Option[String], bodyAttributes: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = HtmlFormat.empty, propositionHeader:Html = HtmlFormat.empty, homepageUrl:Option[Html] = None, globalHeaderText:Option[Html] = None, cookieMessage: Option[Html] = None, skipLinkMessage:Option[Html], logoLinkTitle:Option[Html] = None, licenceMessage:Html, crownCopyrightMessage:Option[Html])(content:Html)',
       head: '@head',
       body_classes: '@bodyClasses.getOrElse("")',
+      body_attributes: '@bodyAttributes.getOrElse("")',
       header_class: '@headerClass',
       proposition_header: '@propositionHeader',
       content: '@content',

--- a/build_tools/packager/webjar_packager.rb
+++ b/build_tools/packager/webjar_packager.rb
@@ -42,7 +42,7 @@ module Packager
       end
       File.open(@target_dir.join('VERSION'), 'w') {|f| f.write "#{GovukTemplate::VERSION}\n" }
     end
-    
+
     def process_template(file)
       target_dir = @internal_dir.join(File.dirname(file))
       target_dir.mkpath

--- a/docs/template-blocks.md
+++ b/docs/template-blocks.md
@@ -7,6 +7,7 @@
 | page_title                | Text inside the `<title>` element               | GOV.UK - The best place to find government services and information
 | head                      | Before closing `</head>` element                | Insertion point
 | body_classes              | Classes to be added to the `<body>` element     | Insertion point
+| body_attributes           | Attributes to be added to the `<body>` element  | Insertion point
 | body_start                | After opening `<body>` element                  | Insertion point
 | skip_link_message         | Text inside the skip to main content link       | Skip to main content
 | cookie_message            | Text inside the cookie message banner           | `<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>`

--- a/integration_tests/html_rendered_by_each_integration_testing_app_spec.rb
+++ b/integration_tests/html_rendered_by_each_integration_testing_app_spec.rb
@@ -27,7 +27,7 @@ describe "HTML rendered by each integration testing app" do
       end
 
       it "should allow setting_body_classes" do
-        expect(subject).to have_tag("body", with: { class: "custom_body_class" })
+        expect(subject).to have_tag("body", with: { class: "custom_body_class", custom_body_attribute: 'test' })
       end
 
       it "should allow inserting content into body_start" do

--- a/integration_tests/integrations/django/templates/test_template.html
+++ b/integration_tests/integrations/django/templates/test_template.html
@@ -6,6 +6,8 @@
 
 {% block body_classes %}custom_body_class{% endblock body_classes %}
 
+{% block body_attributes %}custom_body_attribute="test"{% endblock %}
+
 {% block body_start %}<inserted-into-body-start></inserted-into-body-start>{% endblock body_start %}
 
 {% block cookie_message %}Custom cookie message{% endblock cookie_message %}

--- a/integration_tests/integrations/jinja/templates/test_template.html
+++ b/integration_tests/integrations/jinja/templates/test_template.html
@@ -6,6 +6,8 @@
 
 {% block body_classes %}custom_body_class{% endblock body_classes %}
 
+{% block body_attributes %}custom_body_attribute="test"{% endblock %}
+
 {% block body_start %}<inserted-into-body-start></inserted-into-body-start>{% endblock body_start %}
 
 {% block cookie_message %}Custom cookie message{% endblock cookie_message %}

--- a/integration_tests/integrations/mustache/test_render.rb
+++ b/integration_tests/integrations/mustache/test_render.rb
@@ -11,6 +11,7 @@ parameters = {
   pageTitle: "This is a custom page title",
   head: "<inserted-into-head></inserted-into-head>",
   bodyClasses: "custom_body_class",
+  bodyAttributes: 'custom_body_attribute="test"',
   bodyStart: "<inserted-into-body-start></inserted-into-body-start>",
   cookieMessage: "Custom cookie message",
   headerClass: "custom_header_class",

--- a/integration_tests/integrations/mustache_inheritance/build.js
+++ b/integration_tests/integrations/mustache_inheritance/build.js
@@ -24,6 +24,7 @@ compiledTemplate = Hogan.compile("\
   {{$pageTitle}}This is a custom page title{{/pageTitle}} \
   {{$head}}<inserted-into-head></inserted-into-head>{{/head}} \
   {{$bodyClasses}}custom_body_class{{/bodyClasses}} \
+  {{$bodyAttributes}}custom_body_attribute=\"test\"{{/bodyAttributes}} \
   {{$bodyStart}}<inserted-into-body-start></inserted-into-body-start>{{/bodyStart}} \
   {{$cookieMessage}}Custom cookie message{{/cookieMessage}} \
   {{$headerClass}}custom_header_class{{/headerClass}} \

--- a/integration_tests/integrations/nunjucks/templates/test_template.html
+++ b/integration_tests/integrations/nunjucks/templates/test_template.html
@@ -6,6 +6,8 @@
 
 {% block body_classes %}custom_body_class{% endblock %}
 
+{% block body_attributes %}custom_body_attribute="test"{% endblock %}
+
 {% block body_start %}<inserted-into-body-start></inserted-into-body-start>{% endblock %}
 
 {% block cookie_message %}Custom cookie message{% endblock %}

--- a/integration_tests/integrations/rails/views/show.html.erb
+++ b/integration_tests/integrations/rails/views/show.html.erb
@@ -6,6 +6,8 @@
 
 <% content_for(:body_classes, "custom_body_class") %>
 
+<% content_for(:body_attributes) do %>custom_body_attribute="test"<% end %>
+
 <% content_for(:body_start) do %><inserted-into-body-start></inserted-into-body-start><% end %>
 
 <% content_for(:cookie_message, "Custom cookie message") %>

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -29,7 +29,7 @@
     <%= yield :head %>
   </head>
 
-  <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>
+  <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %> <%= content_for?(:body_attributes) ? raw("#{yield(:body_attributes)}") : '' %>>
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
     <%= yield :body_start %>

--- a/spec/build_tools/compiler/django_processor_spec.rb
+++ b/spec/build_tools/compiler/django_processor_spec.rb
@@ -5,6 +5,7 @@ def valid_sections
   {
     after_header: "{% block after_header %}{% endblock %}",
     body_classes: "{% block body_classes %}{% endblock %}",
+    body_attributes: "{% block body_attributes %}{% endblock %}",
     body_end: "{% block body_end %}{% endblock %}",
     content: "{% block content %}{% endblock %}",
     cookie_message: "{% block cookie_message %}{% endblock %}",

--- a/spec/build_tools/compiler/ejs_processor_spec.rb
+++ b/spec/build_tools/compiler/ejs_processor_spec.rb
@@ -7,6 +7,7 @@ def valid_sections
     page_title: "<%- partial('partials/_page_title') %>",
     head: "<%- partial('partials/_head') %>",
     body_classes: "<%= bodyClasses %>",
+    body_attributes: "<%= bodyAttributes %>",
     content: "<%- partial('partials/_content') %>",
     body_end: "<%- partial('partials/_body_end') %>",
     footer_top: "<%- partial('partials/_footer_top') %>",

--- a/spec/build_tools/compiler/jinja_processor_spec.rb
+++ b/spec/build_tools/compiler/jinja_processor_spec.rb
@@ -5,6 +5,7 @@ def valid_sections
   {
     after_header: "{% block after_header %}{% endblock %}",
     body_classes: "{% block body_classes %}{% endblock %}",
+    body_attributes: "{% block body_attributes %}{% endblock %}",
     body_end: "{% block body_end %}{% endblock %}",
     content: "{% block content %}{% endblock %}",
     cookie_message: "{% block cookie_message %}{% endblock %}",

--- a/spec/build_tools/compiler/mustache_processor_spec.rb
+++ b/spec/build_tools/compiler/mustache_processor_spec.rb
@@ -7,6 +7,7 @@ def valid_sections
     page_title: "{{ pageTitle }}",
     head: "{{{ head }}}",
     body_classes: "{{ bodyClasses }}",
+    body_attributes: "{{{ bodyAttributes }}}",
     content: "{{{ content }}}",
     body_end: "{{{ bodyEnd }}}",
     top_of_page: "{{{ topOfPage }}}",


### PR DESCRIPTION
**What does it do?**

I've inheritied a project which relies on GA event tagging being driven by attributes dynamically added to the body tag.
Would you accept a modification which allows for a block variable being added to the body tag? This should be a non-breaking change for anyone not using this block var.

This change would allow uses of the template to specify custom attributes on the body tag if they so wish, the default would remain blank. We use it like this:

`<body class="{% block body_classes %}{% endblock %}" {% block body_attributes %}{% endblock %}>`

to render HTML like this:

`<body class="noscript" data-journey="report-benefit-fraud:stage:details" >`

**What type of change is it?**

New feature (non-breaking change which adds functionality)