### PR TITLE
Add bundle install to before_deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
   - bundle exec rake spec integration_tests
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
+- bundle install
 deploy:
 - provider: script
   script: ./config.sh


### PR DESCRIPTION
The most recent build on master failed with the following error:

Could not find gem 'sprockets (= 2.10.0) ruby' in the gems available on
this machine.

Run `bundle install` to install missing gems.

Add bundle install to Travis’ before_deploy to ensure that bundle
install is run for each deploy provider.