### PR TITLE
Move bundle install step to its deploy provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,12 @@ script:
   - bundle exec rake spec integration_tests
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
-- bundle install
 deploy:
 - provider: script
   script: ./config.sh
   on: master
 - provider: script
-  script: 'bundle exec rake build:and_release_if_updated'
+  script: 'bundle install && bundle exec rake build:and_release_if_updated'
   on:
     branch: master
 notifications:


### PR DESCRIPTION
Rather than setting this in before_deploy, which means it will run for
each deploy provider - move it to the deploy provider it relates to (as
it isn’t required for the first).