### PR TITLE
Amends to Travis.yml to reduce log output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ deploy:
   on: master
 - provider: script
   script: 'bundle install && bundle exec rake build:and_release_if_updated'
-  on:
-    branch: master
+  on: master
 after_deploy:
   - rm -rf pkg
   - rm -rf app

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ deploy:
   script: 'bundle install && bundle exec rake build:and_release_if_updated'
   on:
     branch: master
+after_deploy:
+  - rm -rf pkg
+  - rm -rf app
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Remove folders after deployment

To reduce the log output when Travis does ‘git stash apply’ after a
deployment, remove the folders created as part of the build process -
pkg and app.

An example of the logs can be seen in this build:
https://travis-ci.org/alphagov/govuk_template/builds/215589249

Also make the deploy providers consistent. 