### PR TITLE
Change permissions for gem credentials

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -14,4 +14,5 @@ openssl aes-256-cbc -K $encrypted_ed23d39ae37d_key -iv $encrypted_ed23d39ae37d_i
 tar xvf .travis/secrets.tar
 mkdir -p ~/.gem/
 mv secrets/gem_credentials ~/.gem/credentials
+chmod 0600 ~/.gem/credentials
 mv secrets/npmrc ~/.npmrc


### PR DESCRIPTION
The most recent Travis build failed with "Your gem push credentials file located at: `/home/travis/.gem/credentials` has file permissions of 0644 but 0600 is required."