### PR TITLE
[DO NOT MERGE] SRI

### DIFF
--- a/build_tools/compiler/asset_compiler.rb
+++ b/build_tools/compiler/asset_compiler.rb
@@ -102,7 +102,7 @@ module Compiler
           modified = File.open(original.path + '.tmp', 'w')
           contents = original.read
           @integrity_attributes.each do |key, value|
-            asset_expression = Regexp.new "#{key}(.*?)integrity=\"\"(.*?)>"
+            asset_expression = Regexp.new "#{key}(.*?integrity=\")(\".*?)>"
             contents.gsub! asset_expression, "#{key}\\1#{value}\\2>"
           end
           modified.puts contents
@@ -163,9 +163,8 @@ module Compiler
     end
 
     def generate_integrity_attribute file
-      attribute = 'integrity="sha256-'
+      attribute = 'sha256-'
       attribute << Digest::SHA256.hexdigest(file.to_s)
-      attribute << '"'
       attribute
     end
   end

--- a/build_tools/compiler/asset_compiler.rb
+++ b/build_tools/compiler/asset_compiler.rb
@@ -29,6 +29,7 @@ module Compiler
       compile_javascripts
       compile_stylesheets
       copy_views
+      add_integrity_to_views
       copy_static_assets
       copy_needed_toolkit_assets
     end
@@ -90,6 +91,23 @@ module Compiler
         end
 
         abort "Error copying views:\n#{output}" if status.exitstatus > 0
+      end
+    end
+
+    def add_integrity_to_views
+      Dir.chdir @repo_root.join("app", "views") do
+        Dir.glob("**/*") do |file|
+          next if File.directory?(file)
+          original = File.open(file)
+          modified = File.open(original.path + '.tmp', 'w')
+          contents = original.read
+          @integrity_attributes.each do |key, value|
+            contents.gsub! "#{key}\" %>\"", "#{key}\" %>\" #{value}"
+          end
+          modified.puts contents
+          File.delete(file)
+          File.rename(modified, file)
+        end
       end
     end
 

--- a/build_tools/compiler/asset_compiler.rb
+++ b/build_tools/compiler/asset_compiler.rb
@@ -106,6 +106,7 @@ module Compiler
             contents.gsub! asset_expression, "#{key}\\1#{value}\\2>"
           end
           modified.puts contents
+          modified.close
           File.delete(file)
           File.rename(modified, file)
         end

--- a/build_tools/compiler/asset_compiler.rb
+++ b/build_tools/compiler/asset_compiler.rb
@@ -102,7 +102,8 @@ module Compiler
           modified = File.open(original.path + '.tmp', 'w')
           contents = original.read
           @integrity_attributes.each do |key, value|
-            contents.gsub! "#{key}\" %>\"", "#{key}\" %>\" #{value}"
+            asset_expression = Regexp.new "#{key}(.*?)integrity=\"\"(.*?)>"
+            contents.gsub! asset_expression, "#{key}\\1#{value}\\2>"
           end
           modified.puts contents
           File.delete(file)

--- a/build_tools/compiler/asset_compiler.rb
+++ b/build_tools/compiler/asset_compiler.rb
@@ -164,9 +164,8 @@ module Compiler
     end
 
     def generate_integrity_attribute file
-      attribute = 'sha256-'
-      attribute << Digest::SHA256.hexdigest(file.to_s)
-      attribute
+      sha256 = Digest::SHA256.file(file.path)
+      Sprockets::DigestUtils.integrity_uri(sha256)
     end
   end
 end

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,6 +4,7 @@ The source files are in the `/source` directory.  The `compile` rake task builds
 
 * compiling all stylesheets referenced in `/manifests.yml` to plain CSS (actually css.erb, so the Rails asset pipeline can work in the gem).
 * combining all JavaScript files referenced in `/manifests.yml` (using Sprockets)
+* inserting integrity values for the above CSS/JS into empty integrity attributes in the template
 * copying the images across (including any needed images from the toolkit)
 
 This resulting app directory is included in the gem and hooked in as a Rails engine

--- a/govuk_template.gemspec
+++ b/govuk_template.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 3.1"
 
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'sprockets', '2.10.0'
+  spec.add_development_dependency 'sprockets'
   spec.add_development_dependency 'sass', '3.2.9'
   spec.add_development_dependency 'govuk_frontend_toolkit', '5.2.0'
   spec.add_development_dependency 'gem_publisher', '1.3.0'

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -6,11 +6,11 @@
     <meta charset="utf-8" />
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
-    <!--[if gt IE 8]><!--><link href="<%= asset_path "govuk-template.css" %>" media="screen" rel="stylesheet" integrity="" /><!--<![endif]-->
+    <!--[if gt IE 8]><!--><link href="<%= asset_path "govuk-template.css" %>" media="screen" rel="stylesheet" integrity="" crossorigin="anonymous" /><!--<![endif]-->
     <!--[if IE 6]><link href="<%= asset_path "govuk-template-ie6.css" %>" media="screen" rel="stylesheet" /><![endif]-->
     <!--[if IE 7]><link href="<%= asset_path "govuk-template-ie7.css" %>" media="screen" rel="stylesheet" /><![endif]-->
     <!--[if IE 8]><link href="<%= asset_path "govuk-template-ie8.css" %>" media="screen" rel="stylesheet" /><![endif]-->
-    <link href="<%= asset_path "govuk-template-print.css" %>" integrity="" media="print" rel="stylesheet" />
+    <link href="<%= asset_path "govuk-template-print.css" %>" integrity="" media="print" rel="stylesheet" crossorigin="anonymous" />
 
     <!--[if IE 8]><link href="<%= asset_path "fonts-ie8.css" %>" media="all" rel="stylesheet" /><![endif]-->
     <!--[if gte IE 9]><!--><link href="<%= asset_path "fonts.css" %>" media="all" rel="stylesheet" /><!--<![endif]-->
@@ -104,7 +104,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <script src="<%= asset_path "govuk-template.js" %>" integrity=""></script>
+    <script src="<%= asset_path "govuk-template.js" %>" integrity="" crossorigin="anonymous"></script>
 
     <%= yield :body_end %>
 

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -6,11 +6,11 @@
     <meta charset="utf-8" />
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
-    <!--[if gt IE 8]><!--><link href="<%= asset_path "govuk-template.css" %>" media="screen" rel="stylesheet" /><!--<![endif]-->
+    <!--[if gt IE 8]><!--><link href="<%= asset_path "govuk-template.css" %>" media="screen" rel="stylesheet" integrity="" /><!--<![endif]-->
     <!--[if IE 6]><link href="<%= asset_path "govuk-template-ie6.css" %>" media="screen" rel="stylesheet" /><![endif]-->
     <!--[if IE 7]><link href="<%= asset_path "govuk-template-ie7.css" %>" media="screen" rel="stylesheet" /><![endif]-->
     <!--[if IE 8]><link href="<%= asset_path "govuk-template-ie8.css" %>" media="screen" rel="stylesheet" /><![endif]-->
-    <link href="<%= asset_path "govuk-template-print.css" %>" media="print" rel="stylesheet" />
+    <link href="<%= asset_path "govuk-template-print.css" %>" integrity="" media="print" rel="stylesheet" />
 
     <!--[if IE 8]><link href="<%= asset_path "fonts-ie8.css" %>" media="all" rel="stylesheet" /><![endif]-->
     <!--[if gte IE 9]><!--><link href="<%= asset_path "fonts.css" %>" media="all" rel="stylesheet" /><!--<![endif]-->
@@ -104,7 +104,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <script src="<%= asset_path "govuk-template.js" %>"></script>
+    <script src="<%= asset_path "govuk-template.js" %>" integrity=""></script>
 
     <%= yield :body_end %>
 

--- a/spec/build_tools/compiler/all_compilers_spec.rb
+++ b/spec/build_tools/compiler/all_compilers_spec.rb
@@ -28,3 +28,19 @@ describe "Behaviours all compilers must support every value that gets yielded in
     end
   end
 end
+
+describe 'Integrity attribute values' do
+  it 'should be generated correctly' do
+    compiler = Compiler::AssetCompiler.new
+    content = 'Testing integrity attributes'
+    sha = 'sha256-43c990e55eb6eeb7b219b85c158c587617117c9d80c43bd9f362c38c32933c74'
+    expect(compiler.send(:generate_integrity_attribute, content)).to eq(sha)
+  end
+
+  it 'should be added to the layout template' do
+    compiler = Compiler::AssetCompiler.new
+    compiler.compile
+    output = File.open(repo_root.join('app', 'views', 'layouts', 'govuk_template.html.erb')).read
+    expect(output).to match(/integrity="sha256-\h*?"/)
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/oFhtO0Gm/146-enable-subresource-integrity-sri-on-government-frontend-l)

[Github Issue](https://github.com/alphagov/govuk_template/issues/238)

This PR will generate integrity hashes for tagged <link>s and <script>s and compile them into the template. 

The [Subresource Integrity specification](https://www.w3.org/TR/SRI/) adds a new `integrity` attribute to `<script>` and `<link>` elements that is a hash of the asset they point to. Browsers that support SRI can then hash the downloaded asset and check that it matches the hash specified in the integrity attribute. This [was recently implemented](https://github.com/alphagov/verify-frontend/pull/192) on [verify-frontend](https://github.com/alphagov/verify-frontend/) for the application specific files, and is now being turned on for the govuk_template styles and scripts as well.

On verify-frontend it was as simple as using [sprockets-rails](https://github.com/rails/sprockets-rails) `integrity` attribute passed into `javascript_include_tag` and `stylesheet_link_tag` but as we compile govuk_template into multiple different template languages we can’t do that here. To implement this we’ll have to hash [govuk-template.js](https://github.com/alphagov/govuk_template/blob/master/source/assets/javascripts/govuk-template.js) and [govuk-template.scss](https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/govuk-template.scss) post-compilation, and add those hashes manually to an `integrity` attribute on their respective `<script>` and `<link>` tags.

Still to do: fix the tests and add some more around this functionality, and check to make sure that everything is still being packaged correctly.

Depends on: 
- government-frontend: https://github.com/alphagov/government-frontend/pull/331
- static: https://github.com/alphagov/static/pull/1008