### PR TITLE
Version 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.1
+- Fix invalid html from Apple touch icons syntax ([PR #300]https://github.com/alphagov/govuk_template/pull/300) and
+update icon sizes to match Apple specs
+
 # 0.20.0
 
 - Fix EJS template ([PR #270](https://github.com/alphagov/govuk_template/pull/270))

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.20.0"
+  VERSION = "0.20.1"
 end


### PR DESCRIPTION
Fixes invalid html from Apple touch icons syntax PR https://github.com/alphagov/govuk_template/pull/300 and updates icon sizes to match Apple specs