### PR TITLE
Version 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Development
+# 0.21.0
 
 - Adds SRI to js and css assets ([PR #301](https://github.com/alphagov/govuk_template/pull/301)). This requires `sprockets-rails` >= 3.0 in the projects using this gem.
 

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.20.1"
+  VERSION = "0.21.0"
 end


### PR DESCRIPTION
Adds SRI to css and js assets served by this gem. In order for SRI to work, the applications using this gem will need to upgrade to `sprockets-rails` >= 3.0.0.
Having an older version will not prevent you from upgrading, but will not give you the benefit of using SRI.