### PR TITLE
Adds new icons to precompile list

### DIFF
--- a/lib/govuk_template/engine.rb
+++ b/lib/govuk_template/engine.rb
@@ -7,10 +7,10 @@ module GovukTemplate
         fonts*.css
         govuk-template.js
         ie.js
-        apple-touch-icon-120x120.png
+        apple-touch-icon-180x180.png
+        apple-touch-icon-167x167.png
         apple-touch-icon-152x152.png
-        apple-touch-icon-60x60.png
-        apple-touch-icon-76x76.png
+        apple-touch-icon.png
         gov.uk_logotype_crown_invert.png
         gov.uk_logotype_crown_invert_trans.png
         gov.uk_logotype_crown.svg


### PR DESCRIPTION
Following this commit: https://github.com/alphagov/govuk_template/commit/82d9459596581623ca70f8d415a9117026c20414

The icons will also have to be precompiled in order to be served to other projects.