### PR TITLE
Bump version to v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.22.1
+
+- This release is just to check that the automated downstream packages are now being released correctly. It does not include any changes to the template itself.
+
 # 0.22.0
 
 - Adds new Apple touch icons to precompile list for Rails apps [PR #305](https://github.com/alphagov/govuk_template/pull/305)

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.22.0"
+  VERSION = "0.22.1"
 end


### PR DESCRIPTION
This release is just to check that the automated downstream packages are now being released correctly. It does not include any changes to the template itself.