### PR TITLE
Revert Add text-decoration-skip: ink to all links on GOV.UK

### DIFF
--- a/source/assets/stylesheets/_basic.scss
+++ b/source/assets/stylesheets/_basic.scss
@@ -80,7 +80,6 @@ fieldset {
 
 a:link {
   color: $link-colour;
-  text-decoration-skip: ink;
 }
 
 a:visited {


### PR DESCRIPTION
We added underline skipping to hopefully make some content easier to read but looking
at some examples as seen at https://github.com/alphagov/govuk_template/issues/313 Chrome does a poor job of rendering underlines resulting in potentially confusing underlines that look like punctuation

This revert puts our links back to the 'boring' state of doing nothing special.