### PR TITLE
Fix django package

### DIFF
--- a/source/django/setup.py.erb
+++ b/source/django/setup.py.erb
@@ -3,6 +3,7 @@ from setuptools import setup
 setup(
   name = 'govuk_template_<%= template_abbreviation %>',
   packages = ['govuk_template'],
+  include_package_data=True,
   version = '<%= GovukTemplate::VERSION %>',
   license = 'MIT',
   description = '<%= template_name %> packaged version of the GOV.UK template',

--- a/source/django/setup.py.erb
+++ b/source/django/setup.py.erb
@@ -9,6 +9,6 @@ setup(
   description = '<%= template_name %> packaged version of the GOV.UK template',
   author = 'Government Digital Service developers',
   url = 'http://github.com/alphagov/govuk_template',
-  download_url = 'https://github.com/alphagov/govuk_template/releases/download/<%= GovukTemplate::VERSION %>/<%= template_abbreviation %>_govuk_template-<%= GovukTemplate::VERSION %>.tgz',
+  download_url = 'https://github.com/alphagov/govuk_template/releases/download/v<%= GovukTemplate::VERSION %>/<%= template_abbreviation %>_govuk_template-<%= GovukTemplate::VERSION %>.tgz',
   keywords = ["alphagov", "govuk", "<%= template_abbreviation %>", "template"],
 )


### PR DESCRIPTION
This is made up of two parts.

## Include assets in Django Python package

setuptools will not look for a `MANIFEST.in` unless the `include_package_data` flag is set to `True`.

This is described in the [setuptools documentation](http://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=include_package_data#including-data-files)

And in a slightly easier to understand way in the [Flask docs](http://flask.pocoo.org/docs/0.12/patterns/distribute/#basic-setup-script)

## Fix the `download_url`
The release tags have a v prepended to the version.