### PR TITLE
Revert "Add docs for adding tabindex="-1" to fix the skiplink"

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,13 +8,6 @@ Refer to the table of [template blocks](./docs/template-blocks.md) and their def
 
 The [govuk_template sets a skip link](https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb#L64-L68) to `#content`, but doesn't provide an element with `id="content"`. You'll need to add `id="content"` to your main content area, to ensure the skip link will work.
 
-    <main id="content" role="main" tabindex="-1">
-
-It is recommended to use the main element, with a role of main (to support older assistive technology), also `tabindex="-1"` is required to fix the issue [with focus in Safari](https://bugs.chromium.org/p/chromium/issues/detail?id=37721).
-
-You can see an [example of this working in GOV.UK elements](https://github.com/alphagov/govuk_elements/blob/master/app/views/index.html#L9).
-
-
 ## Propositional title and navigation
 
 You can get a propositional title and navigation by setting the content for `header_class` to `with-proposition` and `proposition_header` in the form:


### PR DESCRIPTION
This reverts commit 858d9198e78b4622962abd7c43572bfc9572f7ea.

Putting tabindex on the `<main>` element causes different problems:
* Some apps will display the browser's default focus styles around the main element
* When clicking anywhere in the page focus will return back to the top

Consider a user interacting with an input field who clicks away from it to remove
the focus style. Should they then hit tab they will be taken to the top of the page.

The [linked to browser bug](https://bugs.chromium.org/p/chromium/issues/detail?id=37721) was fixed in Apr. Testing on Safari 10.1.1 it works with VoiceOver on desktop. Testing on iOS 10.2.1 it works in mobile Safari with VoiceOver on.

More context around the issue:
https://github.com/twbs/bootstrap/issues/20732

## Example problem
GIF showing focus styles and tab order problem on Registers:

![focus-order-issue-tabindex-main](https://user-images.githubusercontent.com/319055/28467721-b49b1ebc-6e28-11e7-8b52-fe163bedba8f.gif)
