### PR TITLE
Add SRI attributes to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Development
+
+- Re-adds SRI for js and css assets removed in 0.22.0
+
 # 0.22.3
 
 - Fix the Django package – ensure setuptools uses the MANIFEST.in by setting the include_package_data flag to True, and fix a broken download link ([PR #319](https://github.com/alphagov/govuk_template/pull/319)).

--- a/build_tools/compiler/template_processor.rb
+++ b/build_tools/compiler/template_processor.rb
@@ -1,4 +1,6 @@
 require 'erb'
+require 'active_support/core_ext/hash'
+require 'active_support/core_ext/array'
 
 module Compiler
   class TemplateProcessor
@@ -38,5 +40,42 @@ module Compiler
     def method_missing(name, *args)
       puts "#{name} #{args.inspect}"
     end
+
+    def stylesheet_link_tag(*sources)
+      options = sources.extract_options!.stringify_keys
+      sources.uniq.map { |source|
+        link_options = {
+            "rel" => "stylesheet",
+            "media" => "screen",
+            "href" => asset_path(source)
+        }.merge!(options)
+        "<link#{tag_options(link_options)}/>"
+      }.join("\n")
+    end
+
+    def javascript_include_tag(*sources)
+      options = sources.extract_options!.stringify_keys
+      sources.uniq.map { |source|
+        script_options = {
+            "src" => asset_path(source)
+        }.merge!(options)
+        "<script#{tag_options(script_options)}></script>"
+      }.join("\n")
+    end
+
+  private
+    def tag_options(options)
+      return if options.empty?
+      output = "".dup
+      sep    = " "
+      options.each_pair do |key, value|
+        if !value.nil?
+          output << sep
+          output << %(#{key}="#{value}")
+        end
+      end
+      output unless output.empty?
+    end
+
   end
 end

--- a/build_tools/compiler/template_processor.rb
+++ b/build_tools/compiler/template_processor.rb
@@ -42,7 +42,7 @@ module Compiler
     end
 
     def stylesheet_link_tag(*sources)
-      options = sources.extract_options!.stringify_keys
+      options = extract_options_excluding_sri_fields(sources)
       sources.uniq.map { |source|
         link_options = {
             "rel" => "stylesheet",
@@ -54,7 +54,7 @@ module Compiler
     end
 
     def javascript_include_tag(*sources)
-      options = sources.extract_options!.stringify_keys
+      options = extract_options_excluding_sri_fields(sources)
       sources.uniq.map { |source|
         script_options = {
             "src" => asset_path(source)
@@ -64,6 +64,11 @@ module Compiler
     end
 
   private
+
+    def extract_options_excluding_sri_fields(sources)
+      sources.extract_options!.stringify_keys.except("integrity", "crossorigin")
+    end
+
     def tag_options(options)
       return if options.empty?
       output = "".dup

--- a/docs/using-with-rails.md
+++ b/docs/using-with-rails.md
@@ -38,3 +38,21 @@ Or to add content to `<head>`, for stylesheets or similar:
 ```
 
 Check out the [full list of blocks](template-blocks.md) you can use to customise the template.
+
+## SRI
+
+`govuk_template` >= 20.0.0 can be used together with `sprockets-rails` >= 3.0.0 in order to make use of the SRI
+
+You can read more about SRI [here](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).
+
+SRI will add an `integrity` attribute on your script tags:
+
+`<script src="https://example.com/example.css"
+integrity="sha384oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8w"
+crossorigin="anonymous"></script>`
+
+The example above is generated automatically by sprockets-rails in your project if the integrity option is set to true:
+
+`<%= stylesheet_script_tag 'example', integrity: true %>`
+
+There is [a bug in Firefox versions less than 52](https://bug623317.bugzilla.mozilla.org/show_bug.cgi?id=1269241) which means it interprets the SRI hash incorrectly for CSS files that start with [the UTF8 byte order mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8).  Sprockets-rails will include a UTF8 BOM in the compiled CSS file if any of the source stylesheets have UTF8 characters in them and this means Firefox < 52 will refuse to load these assets.  To avoid this we developed the [asset_bom_removal-rails](https://github.com/alphagov/asset_bom_removal-rails) gem to strip the UTF8 BOM from compiled CSS assets as part of the rails asset pipeline.

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -6,15 +6,15 @@
     <meta charset="utf-8" />
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
-    <!--[if gt IE 8]><!--><link href="<%= asset_path "govuk-template.css" %>" media="screen" rel="stylesheet" /><!--<![endif]-->
-    <!--[if IE 6]><link href="<%= asset_path "govuk-template-ie6.css" %>" media="screen" rel="stylesheet" /><![endif]-->
-    <!--[if IE 7]><link href="<%= asset_path "govuk-template-ie7.css" %>" media="screen" rel="stylesheet" /><![endif]-->
-    <!--[if IE 8]><link href="<%= asset_path "govuk-template-ie8.css" %>" media="screen" rel="stylesheet" /><![endif]-->
-    <link href="<%= asset_path "govuk-template-print.css" %>" media="print" rel="stylesheet" />
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "govuk-template.css" %><!--<![endif]-->
+    <!--[if IE 6]><%= stylesheet_link_tag "govuk-template-ie6.css" %><![endif]-->
+    <!--[if IE 7]><%= stylesheet_link_tag "govuk-template-ie7.css" %><![endif]-->
+    <!--[if IE 8]><%= stylesheet_link_tag "govuk-template-ie8.css" %><![endif]-->
+    <%= stylesheet_link_tag "govuk-template-print.css", media: "print" %>
 
-    <!--[if IE 8]><link href="<%= asset_path "fonts-ie8.css" %>" media="all" rel="stylesheet" /><![endif]-->
-    <!--[if gte IE 9]><!--><link href="<%= asset_path "fonts.css" %>" media="all" rel="stylesheet" /><!--<![endif]-->
-    <!--[if lt IE 9]><script src="<%= asset_path "ie.js" %>"></script><![endif]-->
+    <!--[if IE 8]><%= stylesheet_link_tag "fonts-ie8.css", media: "all" %><![endif]-->
+    <!--[if gte IE 9]><!--><%= stylesheet_link_tag "fonts.css", media: "all" %><!--<![endif]-->
+    <!--[if lt IE 9]><%= javascript_include_tag "ie.js" %><![endif]-->
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <%# the colour used for mask-icon is the standard palette $black from
@@ -104,7 +104,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <script src="<%= asset_path "govuk-template.js" %>"></script>
+    <%= javascript_include_tag "govuk-template.js" %>
 
     <%= yield :body_end %>
 

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -6,15 +6,15 @@
     <meta charset="utf-8" />
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "govuk-template.css" %><!--<![endif]-->
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "govuk-template.css", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
     <!--[if IE 6]><%= stylesheet_link_tag "govuk-template-ie6.css" %><![endif]-->
     <!--[if IE 7]><%= stylesheet_link_tag "govuk-template-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "govuk-template-ie8.css" %><![endif]-->
-    <%= stylesheet_link_tag "govuk-template-print.css", media: "print" %>
+    <%= stylesheet_link_tag "govuk-template-print.css", media: "print", integrity: true, crossorigin: "anonymous" %>
 
     <!--[if IE 8]><%= stylesheet_link_tag "fonts-ie8.css", media: "all" %><![endif]-->
-    <!--[if gte IE 9]><!--><%= stylesheet_link_tag "fonts.css", media: "all" %><!--<![endif]-->
-    <!--[if lt IE 9]><%= javascript_include_tag "ie.js" %><![endif]-->
+    <!--[if gte IE 9]><!--><%= stylesheet_link_tag "fonts.css", media: "all", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
+    <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: true, crossorigin: "anonymous" %><![endif]-->
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <%# the colour used for mask-icon is the standard palette $black from
@@ -104,7 +104,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <%= javascript_include_tag "govuk-template.js" %>
+    <%= javascript_include_tag "govuk-template.js", integrity: true, crossorigin: "anonymous" %>
 
     <%= yield :body_end %>
 

--- a/spec/build_tools/compiler/django_processor_spec.rb
+++ b/spec/build_tools/compiler/django_processor_spec.rb
@@ -26,6 +26,8 @@ describe Compiler::DjangoProcessor do
   let(:file) {"some/file.erb"}
   subject {described_class.new(file)}
 
+  it_behaves_like "a processor"
+
   describe "#handle_yield" do
     valid_sections.each do |key, content|
       it "should render #{content} for #{key}" do

--- a/spec/build_tools/compiler/ejs_processor_spec.rb
+++ b/spec/build_tools/compiler/ejs_processor_spec.rb
@@ -23,6 +23,8 @@ describe Compiler::EJSProcessor do
   let(:file) {"some/file.erb"}
   subject {described_class.new(file)}
 
+  it_behaves_like "a processor"
+
   describe "#handle_yield" do
     valid_sections.each do |key, content|
       it "should render #{content} for #{key}" do

--- a/spec/build_tools/compiler/jinja_processor_spec.rb
+++ b/spec/build_tools/compiler/jinja_processor_spec.rb
@@ -27,6 +27,8 @@ describe Compiler::JinjaProcessor do
   let(:file) {"some/file.erb"}
   subject {described_class.new(file)}
 
+  it_behaves_like "a processor"
+
   describe "#handle_yield" do
     valid_sections.each do |key, content|
       it "should render #{content} for #{key}" do

--- a/spec/build_tools/compiler/liquid_processor_spec.rb
+++ b/spec/build_tools/compiler/liquid_processor_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require File.join(PROJECT_ROOT, 'build_tools/compiler/liquid_processor.rb')
+
+describe Compiler::LiquidProcessor do
+
+  let(:file) {"some/file.erb"}
+  subject {described_class.new(file)}
+
+  it_behaves_like "a processor"
+
+end

--- a/spec/build_tools/compiler/mustache_inheritance_processor_spec.rb
+++ b/spec/build_tools/compiler/mustache_inheritance_processor_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require File.join(PROJECT_ROOT, 'build_tools/compiler/mustache_inheritance_processor.rb')
+
+describe Compiler::MustacheInheritanceProcessor do
+
+  let(:file) {"some/file.erb"}
+  subject {described_class.new(file)}
+
+  it_behaves_like "a processor"
+
+end

--- a/spec/build_tools/compiler/mustache_processor_spec.rb
+++ b/spec/build_tools/compiler/mustache_processor_spec.rb
@@ -22,6 +22,8 @@ describe Compiler::MustacheProcessor do
   let(:file) {"some/file.erb"}
   subject {described_class.new(file)}
 
+  it_behaves_like "a processor"
+
   describe "#handle_yield" do
     valid_sections.each do |key, content|
       it "should render #{content} for #{key}" do

--- a/spec/build_tools/compiler/plain_processor_spec.rb
+++ b/spec/build_tools/compiler/plain_processor_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require File.join(PROJECT_ROOT, 'build_tools/compiler/plain_processor.rb')
+
+describe Compiler::PlainProcessor do
+
+  let(:file) {"some/file.erb"}
+  subject {described_class.new(file)}
+
+  it_behaves_like "a processor"
+
+end

--- a/spec/build_tools/compiler/play_processor_spec.rb
+++ b/spec/build_tools/compiler/play_processor_spec.rb
@@ -34,6 +34,8 @@ end
 describe Compiler::PlayProcessor do
   subject { described_class.new("dummy filename") }
 
+  it_behaves_like "a processor"
+
   describe "top_of_page" do
     it "declares all of the template parameters" do
       expected_parameter_names.each do |parameter_name|

--- a/spec/support/examples/processor.rb
+++ b/spec/support/examples/processor.rb
@@ -11,6 +11,7 @@ shared_examples_for "a processor" do
 
     describe "#stylesheet_link_tag" do
       let(:css_options) { { "media" => "print" } }
+      let(:sri_attributes) { {"integrity" => true, "crossorigin" => "anonymous"} }
 
       it "writes out a link tag for the requested stylesheet" do
         expect(processor.stylesheet_link_tag(css_source)).to eql("<link rel=\"stylesheet\" media=\"screen\" href=\"#{processor.asset_path(css_source)}\"/>")
@@ -21,10 +22,17 @@ shared_examples_for "a processor" do
           expect(processor.stylesheet_link_tag(css_source, css_options)).to eql("<link rel=\"stylesheet\" media=\"print\" href=\"#{processor.asset_path(css_source)}\"/>")
         end
       end
+
+      context "if sri attributes are present" do
+        it "writes out a link tag for the requested stylesheet without the sri attributes" do
+          expect(processor.stylesheet_link_tag(css_source, sri_attributes)).to eql("<link rel=\"stylesheet\" media=\"screen\" href=\"#{processor.asset_path(css_source)}\"/>")
+        end
+      end
     end
 
     describe "#javascript_include_tag" do
       let(:js_options) { { "charset" => "UTF-8" } }
+      let(:sri_attributes) { { "integrity" => true, "crossorigin" => "anonymous" } }
 
       it "writes out a script tag to include the requested javascript asset" do
         expect(processor.javascript_include_tag(js_source)).to eql("<script src=\"#{processor.asset_path(js_source)}\"></script>")
@@ -33,6 +41,12 @@ shared_examples_for "a processor" do
       context "if charset is provided for the asset" do
         it "writes out a script tag to include the requested javascript asset in the charset" do
           expect(processor.javascript_include_tag(js_source, js_options)).to eql("<script src=\"#{processor.asset_path(js_source)}\" charset=\"UTF-8\"></script>")
+        end
+      end
+
+      context "if sri attributes are present" do
+        it "writes out a script tag to include the requested javascript asset without the sri attributes" do
+          expect(processor.javascript_include_tag(js_source, sri_attributes)).to eql("<script src=\"#{processor.asset_path(js_source)}\"></script>")
         end
       end
     end

--- a/spec/support/examples/processor.rb
+++ b/spec/support/examples/processor.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'set'
+
+shared_examples_for "a processor" do
+  let(:html_erb_file) { "a/file.css" }
+  let(:processor) { described_class.new(html_erb_file) }
+
+  describe "convert rails tags into html" do
+    let(:css_source) { "govuk-template.css" }
+    let(:js_source) { "ie.js" }
+
+    describe "#stylesheet_link_tag" do
+      let(:css_options) { { "media" => "print" } }
+
+      it "writes out a link tag for the requested stylesheet" do
+        expect(processor.stylesheet_link_tag(css_source)).to eql("<link rel=\"stylesheet\" media=\"screen\" href=\"#{processor.asset_path(css_source)}\"/>")
+      end
+
+      context "if css file is for print" do
+        it "writes out a link tag for the requested stylesheet in the print media" do
+          expect(processor.stylesheet_link_tag(css_source, css_options)).to eql("<link rel=\"stylesheet\" media=\"print\" href=\"#{processor.asset_path(css_source)}\"/>")
+        end
+      end
+    end
+
+    describe "#javascript_include_tag" do
+      let(:js_options) { { "charset" => "UTF-8" } }
+
+      it "writes out a script tag to include the requested javascript asset" do
+        expect(processor.javascript_include_tag(js_source)).to eql("<script src=\"#{processor.asset_path(js_source)}\"></script>")
+      end
+
+      context "if charset is provided for the asset" do
+        it "writes out a script tag to include the requested javascript asset in the charset" do
+          expect(processor.javascript_include_tag(js_source, js_options)).to eql("<script src=\"#{processor.asset_path(js_source)}\" charset=\"UTF-8\"></script>")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/uses_of_yield.rb
+++ b/spec/support/uses_of_yield.rb
@@ -32,6 +32,12 @@ class UsesOfYieldInTemplate
   def method_missing(name, *args)
     puts "#{name} #{args.inspect}"
   end
+
+  def stylesheet_link_tag(*sources)
+  end
+
+  def javascript_include_tag(*sources)
+  end
 end
 
 # return an array of unique values passed to yield in the templates


### PR DESCRIPTION
For: https://trello.com/c/SVfWxYYs/205-enable-subresource-integrity-sri-on-static-s

We don't actually add the SRI attributes, but instead add hooks to let the template processors themselves use their own api's to add the SRI attributes.  Currently we only expect the rails version of these to work as we our shims for the other processors ignores the integrity options, but they can be filled in once we know how generate integrity values with them.

Resurrects the work from #301 which was removed in #308 when we realised there was a bug in firefox.