### PR TITLE
Making it possible to not include fonts.css

### DIFF
--- a/build_tools/compiler/django_processor.rb
+++ b/build_tools/compiler/django_processor.rb
@@ -23,6 +23,7 @@ module Compiler
       footer_top:           block_for(:footer_top),
       homepage_url:         statement_tag_for(:homepage_url, 'https://www.gov.uk'),
       global_header_text:   statement_tag_for(:global_header_text, 'GOV.UK'),
+      fonts_stylesheets:    statement_tag_for(:fonts_stylesheets, '<!--[if IE 8]><link href="{% static \"fonts-ie8.css\" %}" media="all" rel="stylesheet" /><![endif]--><!--[if gte IE 9]><!--><link href="{% static \"fonts.css\" %}" media="all" rel="stylesheet" /><!--<![endif]-->'),
       head:                 block_for(:head),
       header_class:         block_for(:header_class),
       html_lang:            statement_tag_for(:html_lang, 'en'),

--- a/build_tools/compiler/ejs_processor.rb
+++ b/build_tools/compiler/ejs_processor.rb
@@ -19,6 +19,8 @@ module Compiler
       footer_top:           partial_for(:footer_top),
       homepage_url:         "<% if (homepageUrl) { %><%= homepageUrl %><% } else { %>https://www.gov.uk/<% } %>",
       global_header_text:   "<% if (globalHeaderText) { %><%= globalHeaderText %><% } %>",
+      fonts_stylesheets:    '<% if (fonts_stylesheets) { %><%= fonts_stylesheets %><% } else { %><!--[if IE 8]><link href="<%= govukTemplateAssetPath %>stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
+          <!--[if gte IE 9]><!--><link href="<%= govukTemplateAssetPath %>stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]--><% } %>',
       head:                 partial_for(:head),
       header_class:         "<% if (headerClass) { %><%= headerClass %><% } %>",
       html_lang:            "<% if (htmlLang) { %><%= htmlLang %><% } else { %>en<% } %>",

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -27,7 +27,7 @@ module Compiler
       footer_top:           block_for(:footer_top),
       homepage_url:         statement_tag_for(:homepage_url, 'https://www.gov.uk'),
       global_header_text:   statement_tag_for(:global_header_text, 'GOV.UK'),
-      fonts_stylesheets:    unescaped_statement_tag_for(:fontsStylesheets, '<!--[if IE 8]><link href="{{ assetPath }}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
+      fonts_stylesheets:    unescaped_statement_tag_for(:fontsStylesheets, '<!--[if IE 8]><link href="{{ asset_path }}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
           <!--[if gte IE 9]><!--><link href="{{ assetPath }}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->'),
       head:                 block_for(:head),
       header_class:         block_for(:header_class),

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -27,6 +27,8 @@ module Compiler
       footer_top:           block_for(:footer_top),
       homepage_url:         statement_tag_for(:homepage_url, 'https://www.gov.uk'),
       global_header_text:   statement_tag_for(:global_header_text, 'GOV.UK'),
+      fonts_stylesheets:    unescaped_statement_tag_for(:fontsStylesheets, '<!--[if IE 8]><link href="{{ assetPath }}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
+          <!--[if gte IE 9]><!--><link href="{{ assetPath }}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->'),
       head:                 block_for(:head),
       header_class:         block_for(:header_class),
       html_lang:            statement_tag_for(:html_lang, 'en'),

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -27,7 +27,7 @@ module Compiler
       footer_top:           block_for(:footer_top),
       homepage_url:         statement_tag_for(:homepage_url, 'https://www.gov.uk'),
       global_header_text:   statement_tag_for(:global_header_text, 'GOV.UK'),
-      fonts_stylesheets:    unescaped_statement_tag_for(:fontsStylesheets, '<!--[if IE 8]><link href="{{ asset_path }}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
+      fonts_stylesheets:    block_for(:fontsStylesheets, '<!--[if IE 8]><link href="{{ asset_path }}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
           <!--[if gte IE 9]><!--><link href="{{ asset_path }}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->'),
       head:                 block_for(:head),
       header_class:         block_for(:header_class),

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -28,7 +28,7 @@ module Compiler
       homepage_url:         statement_tag_for(:homepage_url, 'https://www.gov.uk'),
       global_header_text:   statement_tag_for(:global_header_text, 'GOV.UK'),
       fonts_stylesheets:    unescaped_statement_tag_for(:fontsStylesheets, '<!--[if IE 8]><link href="{{ asset_path }}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
-          <!--[if gte IE 9]><!--><link href="{{ assetPath }}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->'),
+          <!--[if gte IE 9]><!--><link href="{{ asset_path }}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->'),
       head:                 block_for(:head),
       header_class:         block_for(:header_class),
       html_lang:            statement_tag_for(:html_lang, 'en'),

--- a/build_tools/compiler/liquid_processor.rb
+++ b/build_tools/compiler/liquid_processor.rb
@@ -19,6 +19,7 @@ module Compiler
       footer_top:           include_for(:footer_top),
       homepage_url:         "{% if page.homepage_url %}{{ page.homepage_url }}{% else %}https://www.gov.uk/{% endif %}",
       global_header_text:   "{% if page.global_header_text %}{{ page.global_header_text }}{% endif %}",
+      fonts_stylesheets:    '{% if page.fonts_stylesheets %}{{ page.fonts_stylesheets }}{% else %}<!--[if IE 8]><link href="{{ site.govuk_template_assets }}/stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]--><!--[if gte IE 9]><!--><link href="{{ site.govuk_template_assets }}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->{% endif %}',
       head:                 include_for(:head),
       header_class:         "{% if page.header_class %}{{ page.header_class }}{% endif %}",
       html_lang:            "{% if page.html_lang %}{{ page.html_lang }}{% else %}en{% endif %}",

--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -19,6 +19,8 @@ module Compiler
       footer_top:           tag_for(:footerTop),
       homepage_url:         tag_for(:homepageUrl, "https://www.gov.uk/"),
       global_header_text:   tag_for(:globalHeaderText, "GOV.UK"),
+      fonts_stylesheets:    tag_for(:fontsStylesheets, '<!--[if IE 8]><link href="{{{ assetPath }}}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
+          <!--[if gte IE 9]><!--><link href="{{{ assetPath }}}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->'),
       head:                 tag_for(:head),
       header_class:         tag_for(:headerClass),
       html_lang:            tag_for(:htmlLang, "en"),

--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -23,6 +23,8 @@ module Compiler
       footer_top:           unescaped_html_tag_for(:footerTop),
       homepage_url:         unescaped_html_tag_for(:homepageUrl),
       global_header_text:   unescaped_html_tag_for(:globalHeaderText),
+      fonts_stylesheets:    '<!--[if IE 8]><link href="{{{ assetPath }}}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
+          <!--[if gte IE 9]><!--><link href="{{{ assetPath }}}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->',
       head:                 unescaped_html_tag_for(:head),
       header_class:         unescaped_html_tag_for(:headerClass),
       html_lang:            tag_for(:htmlLang),

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -12,7 +12,7 @@ module Compiler
       # top_of_page has a special purpose: it is required by Play to define the
       # parameters to pass when rendering
       # https://www.playframework.com/documentation/2.2.x/ScalaTemplates#Template-parameters
-      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = HtmlFormat.empty, propositionHeader:Html = HtmlFormat.empty, homepageUrl:Option[Html] = None, globalHeaderText:Option[Html] = None, cookieMessage: Option[Html] = None, skipLinkMessage:Option[Html], logoLinkTitle:Option[Html] = None, licenceMessage:Html, crownCopyrightMessage:Option[Html])(content:Html)',
+      top_of_page: '@(title: Option[String], bodyClasses: Option[String], htmlLang: Option[String] = None)(head:Html, bodyStart:Html, bodyEnd:Html, insideHeader:Html, afterHeader:Html, footerTop:Html, footerLinks:Html, headerClass:Html = HtmlFormat.empty, propositionHeader:Html = HtmlFormat.empty, homepageUrl:Option[Html] = None, globalHeaderText:Option[Html] = None, cookieMessage: Option[Html] = None, skipLinkMessage:Option[Html], logoLinkTitle:Option[Html] = None, licenceMessage:Html, crownCopyrightMessage:Option[Html])(content:Html), fontsStylesheets:Option[Html])(content:Html)',
       head: '@head',
       body_classes: '@bodyClasses.getOrElse("")',
       header_class: '@headerClass',
@@ -31,6 +31,8 @@ module Compiler
       logo_link_title: '@logoLinkTitle.getOrElse("Go to the GOV.UK homepage")',
       licence_message: '@licenceMessage',
       crown_copyright_message: '@crownCopyrightMessage.getOrElse("&copy; Crown copyright")',
+      fonts_stylesheets: '@fonts_stylesheets.getOrElse("<!--[if IE 8]><link href=\"@routes.Template.at("fonts-ie8.css")\" media=\"all\" rel=\"stylesheet\" /><![endif]-->
+          <!--[if gte IE 9]><!--><link href=\"@routes.Template.at("fonts.css")\" media=\"all\" rel=\"stylesheet\" /><!--<![endif]-->")',
     }
 
     def render_erb

--- a/build_tools/packager/mustache_inheritance_packager.rb
+++ b/build_tools/packager/mustache_inheritance_packager.rb
@@ -10,6 +10,26 @@ module Packager
       @base_name = "mustache_inheritance_govuk_template-#{GovukTemplate::VERSION}"
     end
 
+    def build
+      @target_dir = @repo_root.join('pkg', @base_name)
+      @target_dir.rmtree if @target_dir.exist?
+      @target_dir.mkpath
+      Dir.chdir(@target_dir) do |dir|
+        generate_package_json
+        prepare_contents
+        create_tarball
+      end
+    end
+
+    def generate_package_json
+      template_abbreviation = "mustache_inheritance"
+      template_name = "{{ mustache }}"
+      contents = ERB.new(File.read(File.join(@repo_root, "source/package.json.erb"))).result(binding)
+      File.open(File.join(@target_dir, "package.json"), "w") do |f|
+        f.write contents
+      end
+    end
+
     def process_template(file)
       target_dir = @target_dir.join(File.dirname(file))
       target_dir.mkpath

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -12,8 +12,9 @@
     <!--[if IE 8]><link href="<%= asset_path "govuk-template-ie8.css" %>" media="screen" rel="stylesheet" /><![endif]-->
     <link href="<%= asset_path "govuk-template-print.css" %>" media="print" rel="stylesheet" />
 
-    <!--[if IE 8]><link href="<%= asset_path "fonts-ie8.css" %>" media="all" rel="stylesheet" /><![endif]-->
-    <!--[if gte IE 9]><!--><link href="<%= asset_path "fonts.css" %>" media="all" rel="stylesheet" /><!--<![endif]-->
+    <% if content_for?(:fonts_stylesheets) %>
+      <%= yield(:fonts_stylesheets) %>
+    <% end %>
     <!--[if lt IE 9]><script src="<%= asset_path "ie.js" %>"></script><![endif]-->
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />


### PR DESCRIPTION
Some of GOV.UK Pay clients want the ability to have their own branded version of our payments form this means that they don't want NTA either, so rather than do a load of overrides, I'd like to not include the CSS at all (this also reduces HTTP reqs)

I'm haven't written much Ruby nor worked on govuk_template before… but does this look like the right approach about making it optional?

### UPDATE
After speaking with @fofr I cleaned this up and have applied it to all templating languages, how does it look?

