### PR TITLE
Fix #325 Focused, unvisited links are (extremely) low-contrast

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -58,10 +58,7 @@ a {
 a:focus {
   background-color: $focus-colour;
   outline: 3px solid $focus-colour;
-}
-
-/* Make links slightly darker when focused to improve contrast. */
-a:link:focus {
+  /* Make links slightly darker when focused to improve contrast. */
   color: darken( $link-colour, 2.5%)
 }
 


### PR DESCRIPTION
This commit fixes #325, which is in essence a fix for PR #272 which was an attempt to fix #264.

If that sounds confusing enough, here is the short story:
- Now we have blue text on green buttons when focused on unvisited links.
- This PR is making use of a "less powerful" selector for improving contrast on links while not affecting buttons.

**Buttons**
Before:
<img width="241" alt="screen shot 2017-09-15 at 14 21 53" src="https://user-images.githubusercontent.com/788096/30484548-9d71dda4-9a22-11e7-8345-6bb8105c4061.png">
After:
<img width="248" alt="screen shot 2017-09-21 at 15 57 26" src="https://user-images.githubusercontent.com/788096/30702843-f647f2ac-9ee5-11e7-9301-68c715c29155.png">

Tested with latest Chrome, Firefox on OSX and Windows and IE9, IE10, IE11 on Windows.
  