### PR TITLE
Fix some meta and link tags not being closed

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -19,18 +19,18 @@
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <%# the colour used for mask-icon is the standard palette $black from
         https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>
-    <link rel="mask-icon" href="<%= asset_path 'gov.uk_logotype_crown.svg' %>" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path "apple-touch-icon-180x180.png" %>">
-    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path "apple-touch-icon-167x167.png" %>">
-    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path "apple-touch-icon-152x152.png" %>">
-    <link rel="apple-touch-icon" href="<%= asset_path "apple-touch-icon.png" %>">
+    <link rel="mask-icon" href="<%= asset_path 'gov.uk_logotype_crown.svg' %>" color="#0b0c0c" />
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path "apple-touch-icon-180x180.png" %>" />
+    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path "apple-touch-icon-167x167.png" %>" />
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path "apple-touch-icon-152x152.png" %>" />
+    <link rel="apple-touch-icon" href="<%= asset_path "apple-touch-icon.png" %>" />
 
     <%# the colour used for theme-color is the standard palette $black from
         https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>
     <meta name="theme-color" content="#0b0c0c" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>" />
 
     <%= yield :head %>
   </head>


### PR DESCRIPTION
**CHANGES:**

While preparing a load test script with JMeter, the XPath parser
would fail because some `link` and `meta` tags weren't closed.