### PR TITLE
Fix proposition menu accessibility

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,37 @@ The source files are in the `/source` directory.  The `compile` rake task builds
 
 This resulting app directory is included in the gem and hooked in as a Rails engine
 
+## Getting a manual test rig setup
+
+You will need a 'test website' to manually verify changes. If you're only modifying the existing assets, you can do this with NodeJS.
+
+```
+npm install -g http-server node-sass
+
+# Serve all the assets in the current directory
+http-server -c-1
+
+# Auto-compile all the SASS to CSS
+node-sass --recursive source/assets/stylesheets --output app/assets/stylesheets --include-path ../govuk_frontend_toolkit/stylesheets --watch
+```
+
+Then create a skeleton `test.html` file in the `app` directory (so git ignores it) using the following template.
+
+```
+<html>
+  <head>
+    <link rel="stylesheet" href="assets/css/govuk-template.css"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body class="js-enabled">
+    YOUR TEST CODE HERE
+  </body>
+  <script type="text/javascript" src="../source/assets/javascripts/govuk-template.js"></script>
+</html>
+  </body>
+</html>
+```
+
 ## Extra details for the tarball build
 
 The tarball build process takes the compiled template and assets from the `/app` directory, and performs some extra processing:

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,13 +13,11 @@ This resulting app directory is included in the gem and hooked in as a Rails eng
 You will need a 'test website' to manually verify changes. If you're only modifying the existing assets, you can do this with NodeJS.
 
 ```
-npm install -g http-server node-sass
-
 # Serve all the assets in the current directory
-http-server -c-1
+npx http-server -c-1
 
 # Auto-compile all the SASS to CSS
-node-sass --recursive source/assets/stylesheets --output app/assets/stylesheets --include-path ../govuk_frontend_toolkit/stylesheets --watch
+npx node-sass --recursive source/assets/stylesheets --output app/assets/stylesheets --include-path ../govuk_frontend_toolkit/stylesheets --watch
 ```
 
 Then create a skeleton `test.html` file in the `app` directory (so git ignores it) using the following template.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,10 +14,10 @@ You can get a propositional title and navigation by setting the content for `hea
 
     <div class="header-proposition">
       <div class="content">
-        <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+        <a href="/" id="proposition-name">Service Name</a>
+        <button href="#proposition-links" class="js-header-toggle menu" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
         <nav id="proposition-menu">
-          <a href="/" id="proposition-name">Service Name</a>
-          <ul id="proposition-links">
+          <ul id="proposition-links" aria-label="Top Level Navigation">
             <li><a href="url-to-page-1" class="active">Navigation item #1</a></li>
             <li><a href="url-to-page-2">Navigation item #2</a></li>
           </ul>
@@ -31,8 +31,8 @@ For menus with only one item, the collapsible functionality is not necessary, it
 
     <div class='header-proposition'>
       <div class='content'>
-        <nav id='proposition-menu'>
-          <a href='/' id='proposition-name'>Service Name</a>
+        <a href='/' id='proposition-name'>Service Name</a>
+        <nav id='proposition-menu' aria-label="Top Level Navigation">
           <p id='proposition-link'>
             <a href='url-to-page-1'>Navigation item #1</a>
           </p>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,7 @@ You can get a propositional title and navigation by setting the content for `hea
     <div class="header-proposition">
       <div class="content">
         <a href="/" id="proposition-name">Service Name</a>
-        <button href="#proposition-links" class="js-header-toggle menu" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+        <a role="button" href="#proposition-links" class="js-header-toggle menu" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</a>
         <nav id="proposition-menu">
           <ul id="proposition-links" aria-label="Top Level Navigation">
             <li><a href="url-to-page-1" class="active">Navigation item #1</a></li>

--- a/source/assets/javascripts/core.js
+++ b/source/assets/javascripts/core.js
@@ -22,10 +22,10 @@
         } else {
           target.setAttribute('class', targetClass + " js-visible");
         }
-        if(sourceClass.indexOf('js-hidden') !== -1){
-          this.setAttribute('class', sourceClass.replace(/(^|\s)js-hidden(\s|$)/, ''));
+        if(sourceClass.indexOf('js-visible') !== -1){
+          this.setAttribute('class', sourceClass.replace(/(^|\s)js-visible(\s|$)/, ''));
         } else {
-          this.setAttribute('class', sourceClass + " js-hidden");
+          this.setAttribute('class', sourceClass + " js-visible");
         }
       });
     }

--- a/source/assets/javascripts/core.js
+++ b/source/assets/javascripts/core.js
@@ -27,6 +27,8 @@
         } else {
           this.setAttribute('class', sourceClass + " js-visible");
         }
+        this.setAttribute('aria-expanded', this.getAttribute('aria-expanded') !== "true");
+        target.setAttribute('aria-hidden', target.getAttribute('aria-hidden') === "false");
       });
     }
   }

--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -13,9 +13,7 @@
 }
 
 /* Hide for both screenreaders and browsers */
-.hidden,
-/* Hide for both screenreaders and browsers when JS enabled */
-.js-enabled .js-hidden {
+.hidden {
   display: none;
   visibility: hidden;
 }

--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -117,13 +117,17 @@
     a#proposition-name:focus {
       color: $text-colour;
     }
-    a.menu {
+    .menu {
       @include core-16;
       color: $white;
       display: block;
       float: right;
       text-decoration: none;
-      padding-top: 6px;
+      font-weight: bold;
+      padding: 2px 6px 1px;
+      font-size: 13px !important;
+      background-color: $black;
+      border-radius: 3px;
       @include media(desktop){
         display: none;
       }

--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -138,7 +138,7 @@
         vertical-align: middle;
         content: " \25BC";
       }
-      &.js-hidden:after {
+      &.js-visible:after {
         content: " \25B2";
       }
     }

--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -117,17 +117,13 @@
     a#proposition-name:focus {
       color: $text-colour;
     }
-    .menu {
+    a.menu {
       @include core-16;
       color: $white;
       display: block;
       float: right;
       text-decoration: none;
-      font-weight: bold;
-      padding: 2px 6px 1px;
-      font-size: 13px !important;
-      background-color: $black;
-      border-radius: 3px;
+      padding-top: 6px;
       @include media(desktop){
         display: none;
       }


### PR DESCRIPTION
Fix two accessibility issues with proposition links:

   - Clicking on the 'Menu' button while using VoiceOver on a narrow-width device would lock the focus on the 'Menu' button with no way to escape. The button is now always visible to avoid this.
   - The proposition links section was difficult to navigate with VoiceOver due to a lack of aria attributes, the 'Menu' being a link (not a button) and the ordering of the 'Service Name' link.

I've also added some docs to help future manual testing.