### PR TITLE
Fix missing js-hidden class (equivalent to .hidden)

### DIFF
--- a/source/assets/stylesheets/_accessibility.scss
+++ b/source/assets/stylesheets/_accessibility.scss
@@ -13,7 +13,8 @@
 }
 
 /* Hide for both screenreaders and browsers */
-.hidden {
+.hidden,
+.js-hidden {
   display: none;
   visibility: hidden;
 }


### PR DESCRIPTION
This was removed in a previous commit as it's not used within this
codebase. It is, however, used externally by downstream projects.