### PR TITLE
Make sure the default opengraph image is the fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Make sure that if a custom `og:image` meta tag is set in the `:head` block,
+  this image has priority over the default image.
+
 # 0.23.2
 
 - Fix missing js-hidden class. This class is still used by downstream projects and should be kept for backwards compatibility.

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -30,9 +30,11 @@
     <meta name="theme-color" content="#0b0c0c" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
 
     <%= yield :head %>
+
+    <%# The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback %>
+    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
   </head>
 
   <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>


### PR DESCRIPTION
Currently when an application sets a custom og:image (which it should), the custom meta tag will be inserted below the default meta tag.

This means that Facebook still sees the big black crown as the primary image and the user has to manually select a new image. Slack doesn't allow you to change the image, so the custom `og:image` is completely ignored.
 
By flipping the meta tag and `:head` inserter, we make sure that the custom image is the first one chosen for the page.

## Effect on Facebook

<img width="515" alt="screen shot 2018-04-18 at 15 27 15" src="https://user-images.githubusercontent.com/233676/38938270-0d41d276-431d-11e8-9cf1-a3dbe4764f25.png">

<img width="515" alt="screen shot 2018-04-18 at 15 27 21" src="https://user-images.githubusercontent.com/233676/38938317-23c6ecd4-431d-11e8-924c-d5490041a0ca.png">

## Effect on Slack

<img width="989" alt="screen shot 2018-04-18 at 15 30 18" src="https://user-images.githubusercontent.com/233676/38938468-7e647d00-431d-11e8-947b-59a3c3d6c3bd.png">

