### PR TITLE
Update crown copyright link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Update the link to the crown copyright page on The National Archives website.
+
 # 0.24.0
 
 - Change font delivery method from Base64 encoded strings to WOFF2, WOFF and EOT files. This has been successfully tested as a more network efficient way to deliver fonts. You need to modify your build scripts to copy the font files to a place where they can be served.

--- a/govuk_template.gemspec
+++ b/govuk_template.gemspec
@@ -6,8 +6,8 @@ require 'govuk_template/version'
 Gem::Specification.new do |spec|
   spec.name          = "govuk_template"
   spec.version       = GovukTemplate::VERSION
-  spec.authors       = ["Alex Tomlins"]
-  spec.email         = ["alex.tomlins@digital.cabinet-office.gov.uk"]
+  spec.authors       = ["GOV.UK Dev"]
+  spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
   spec.summary       = %q{Rails engine supplying the GOV.UK header/footer template}
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/alphagov/govuk_template"

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -97,7 +97,7 @@
           </div>
 
           <div class="copyright">
-            <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/"><%= content_for?(:crown_copyright_message) ? yield(:crown_copyright_message) : "© Crown copyright" %></a>
+            <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"><%= content_for?(:crown_copyright_message) ? yield(:crown_copyright_message) : "© Crown copyright" %></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This commit updates the crown copyright link which points to a page on The National Archives website, which has moved.

It also updates the gem developer details to make them consistent with our other gems.