### PR TITLE
Release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.25.0
 
 - Add event tracking to the GOV.UK logo, in order to measure user engagement with this element.
 

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.24.1"
+  VERSION = "0.25.0"
 end


### PR DESCRIPTION
This PR merges the change to add event tracking to the GOV.UK logo.