### PR TITLE
Add GA tracking to cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add event tracking to the GOV.UK cookie banner
+
 # 0.25.0
 
 - Add event tracking to the GOV.UK logo, in order to measure user engagement with this element.

--- a/source/assets/javascripts/cookie-bar.js
+++ b/source/assets/javascripts/cookie-bar.js
@@ -1,15 +1,25 @@
 (function () {
-  "use strict"
-  var root = this;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+  'use strict'
+  var root = this
+  if (typeof root.GOVUK === 'undefined') { root.GOVUK = {} }
 
   GOVUK.addCookieMessage = function () {
-    var message = document.getElementById('global-cookie-message'),
-        hasCookieMessage = (message && GOVUK.cookie('seen_cookie_message') === null);
+    var message = document.getElementById('global-cookie-message')
+
+    var hasCookieMessage = (message && GOVUK.cookie('seen_cookie_message') === null)
 
     if (hasCookieMessage) {
-      message.style.display = 'block';
-      GOVUK.cookie('seen_cookie_message', 'yes', { days: 28 });
-    }
-  };
-}).call(this);
+      message.style.display = 'block'
+      GOVUK.cookie('seen_cookie_message', 'yes', { days: 28 })
+
+      document.addEventListener('DOMContentLoaded', function (event) {
+        if (GOVUK.analytics && typeof GOVUK.analytics.trackEvent === 'function') {
+          GOVUK.analytics.trackEvent('cookieBanner', 'Cookie banner shown', {
+            value: 1,
+            nonInteraction: true
+          })
+        }
+      })
+    };
+  }
+}).call(this)

--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -51,7 +51,7 @@
       <% if content_for?(:cookie_message) %>
         <%= yield :cookie_message %>
       <% else %>
-        <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+        <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a></p>
       <% end %>
     </div>
 


### PR DESCRIPTION
Add event tracking to the GOV.UK cookie banner allowing measurement
of user engagement with the banner.

This will track
* No of instances banner is served
* No of instances messages is clicked
* No of instances message ignored

This change is necessary as GOV.UK frontend apps currently use [alphagov/static](https://www.github.com/alphagov/static) to serve the main header. Once [alphagov/static](https://www.github.com/alphagov/static) is updated to use the new design system this change can be reverted.