### PR TITLE
Release 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.26.0
 
 - Add event tracking to the GOV.UK cookie banner
 

--- a/lib/govuk_template/version.rb
+++ b/lib/govuk_template/version.rb
@@ -1,3 +1,3 @@
 module GovukTemplate
-  VERSION = "0.25.0"
+  VERSION = "0.26.0"
 end


### PR DESCRIPTION
This PR releases adding [GA tracking to the cookie banner](https://github.com/alphagov/govuk_template/pull/369)