### PR TITLE
[WIP][DO NOT MERGE] Don't apply styles to new cookie banner

### DIFF
--- a/source/assets/stylesheets/_header.scss
+++ b/source/assets/stylesheets/_header.scss
@@ -240,11 +240,12 @@
   display: none; /* shown with JS, always on for non-JS */
 }
 
-#global-cookie-message {
+.gem-c-cookie-banner#global-cookie-message {
   width: 100%;
   background-color: $light-blue-25;
   padding-top: 10px;
   padding-bottom: 10px;
+
   p {
     @extend %site-width-container;
     @include core-16;


### PR DESCRIPTION
We'll be testing a new cookie banner. These styles don't play nicely with the new banner, but we can't remove them yet, while the old banner is still being used (as the new banner is still in testing phase). We can instead make them specifically only apply to the new cookie banner so they don't affect the new one while we're testing.

This isn't ideal code, as we're referring to component class selectors outside the component itself. However, this code should be temporary - when the new banner has been made live, we can remove this styling.

## Current ("old") banner
<img width="786" alt="Screen Shot 2019-05-01 at 15 06 44" src="https://user-images.githubusercontent.com/29889908/57020961-db925900-6c22-11e9-9bf3-f665826d7e2d.png">

## New banner (WIP)
<img width="1048" alt="Screen Shot 2019-05-01 at 15 07 05" src="https://user-images.githubusercontent.com/29889908/57020970-e1883a00-6c22-11e9-9274-52685abc9e28.png">