### PR TITLE
Add deprecation notice to GitHub pages

### DIFF
--- a/data/index.yml
+++ b/data/index.yml
@@ -1,13 +1,45 @@
+globalHeaderText: GOV.UK
+crownCopyrightMessage: "© Crown copyright"
+licenceMessage: "<p>All content is available under the <a href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" rel=\"license\">Open Government Licence v3.0</a>, except where otherwise stated</p>"
 assetPath: /govuk_template/assets/
 head: >
   <style>
-    main { max-width: 960px; margin: 0 15px; }
-    @media (min-width: 641px) { main { margin: 0 30px; } }
-    @media (min-width: 1020px) { main { margin: 0 auto; } }
+    main { max-width: 960px; margin: 30px 15px; }
+    @media (min-width: 641px) { main { margin: 30px 30px; } }
+    @media (min-width: 1020px) { main { margin: 30px auto; } }
+
+    .notification-summary {
+      border: 4px solid #005ea5;
+      margin-top: 15px;
+      margin-bottom: 15px;
+      padding: 15px 10px;
+    }
+    .notification-summary h2 {
+      margin: 0 0 0.83333em 0;
+      font-size: 24px;
+      line-height: 1.25;
+    }
+    .notification-summary p {
+      max-width: 38em;
+    }
+    @media (min-width: 641px) {
+      .notification-summary {
+        border: 5px solid #005ea5;
+        margin-top: 30px;
+        margin-bottom: 30px;
+        padding: 20px 15px 15px;
+      }
+    }
   </style>
 content: >
   <main role="main">
-    <h1>govuk_template</h1>
+    <h1>GOV.UK Template</h1>
+
+    <div class="notification-summary">
+      <h2>GOV.UK Template has now been replaced by the GOV.UK Design System</h2>
+      <p>GOV.UK Template will remain available in case you are currently using it, but is no longer maintained. The Government Digital Service will only carry out major bug fixes and security patches.</p>
+      <p>The <a href="https://www.gov.uk/design-system">GOV.UK Design System</a> will be updated to ensure the things it contains meet level AA of WCAG 2.1, but Elements will not. <a href="https://design-system.service.gov.uk/accessibility/">Read more about accessibility of the GOV.UK Design System</a>.</p>
+    </div>
 
     <h2>Examples</h2>
 

--- a/index.html
+++ b/index.html
@@ -29,9 +29,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>
-  main { max-width: 960px; margin: 0 15px; }
-  @media (min-width: 641px) { main { margin: 0 30px; } }
-  @media (min-width: 1020px) { main { margin: 0 auto; } }
+  main { max-width: 960px; margin: 30px 15px; }
+  @media (min-width: 641px) { main { margin: 30px 30px; } }
+  @media (min-width: 1020px) { main { margin: 30px auto; } }
+    .notification-summary {
+      border: 4px solid #005ea5;
+      margin-top: 15px;
+      margin-bottom: 15px;
+      padding: 15px 10px;
+    }
+    .notification-summary h2 {
+      margin: 0 0 0.83333em 0;
+      font-size: 24px;
+      line-height: 1.25;
+    }
+    .notification-summary p {
+      max-width: 38em;
+    }
+    @media (min-width: 641px) {
+      .notification-summary {
+        border: 5px solid #005ea5;
+        margin-top: 30px;
+        margin-bottom: 30px;
+        padding: 20px 15px 15px;
+      }
+    }
 </style>
 
 
@@ -62,7 +84,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="" title="" id="logo" class="content" data-module="track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
-              <img src="/govuk_template/assets/images/gov.uk_logotype_crown_invert_trans.png?0.26.0" width="36" height="32" alt=""> 
+              <img src="/govuk_template/assets/images/gov.uk_logotype_crown_invert_trans.png?0.26.0" width="36" height="32" alt=""> GOV.UK
             </a>
           </div>
           
@@ -77,7 +99,13 @@
     <div id="global-header-bar"></div>
 
     <main role="main">
-  <h1>govuk_template</h1>
+  <h1>GOV.UK Template</h1>
+
+    <div class="notification-summary">
+      <h2>GOV.UK Template has now been replaced by the GOV.UK Design System</h2>
+      <p>GOV.UK Template will remain available in case you are currently using it, but is no longer maintained. The Government Digital Service will only carry out major bug fixes and security patches.</p>
+      <p>The <a href="https://www.gov.uk/design-system">GOV.UK Design System</a> will be updated to ensure the things it contains meet level AA of WCAG 2.1, but Elements will not. <a href="https://design-system.service.gov.uk/accessibility/">Read more about accessibility of the GOV.UK Design System</a>.</p>
+    </div>
 
   <h2>Examples</h2>
 
@@ -148,13 +176,13 @@
             <div class="open-government-licence">
               <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
               
-                
+              <p>All content is available under the <a href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" rel=\"license\">Open Government Licence v3.0</a>, except where otherwise stated</p>
               
             </div>
           </div>
 
           <div class="copyright">
-            <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"></a>
+            <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Adds a deprecation notice to the [GOV.UK Template documentation hosted on GitHub pages](http://alphagov.github.io/govuk_template/), and also fix:

- the missing 'GOV.UK' text in the header
- the missing 'Crown copyright' in the footer
- the missing OGL license text
- missing top and bottom margins on the #main element

I have not fixed the cookie banner, because the GOV.UK Template documentation does not use cookies (and unfortunately there is no easy way to remove the banner entirely)

Note that index.html is normally [generated by the DocsPublisher][1], based on data/index.yml, but that only happens when a new release gets published.

For that reason, the same changes have been manually applied to index.html. The update should get deployed to GitHub pages as soon as this is merged to the gh-pages branch, and the changes to data.yml should mean that if index.html is re-compiled as part of a future release they won't be overwritten.

## Before

![alphagov github io_govuk_template_](https://user-images.githubusercontent.com/121939/76612358-11c38900-6514-11ea-8333-84c6ef3ef274.png)

## After

![localhost_8000_govuk_template_](https://user-images.githubusercontent.com/121939/76612361-138d4c80-6514-11ea-9407-095ff3d2e494.png)


[1]: https://github.com/alphagov/govuk_template/blob/3bc945d0abe82e6d43a542bc6d8c9088881e1636/build_tools/publisher/docs_publisher.rb#L32-L47