### PR TITLE
Update deprecation notice on alphagov.github.io/govuk_template/

### DIFF
--- a/data/index.yml
+++ b/data/index.yml
@@ -43,7 +43,7 @@ content: >
       <ul>
       <li>no longer maintained</li>
       <li>will only be updated for major bug fixes and security patches</li>
-      <li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
+      <li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps#meeting-accessibility-requirements">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
       </ul>
 
       <p>This framework will remain available in case you’re currently using it. To help your service meet accessibility requirements, you should use the <a href="https://design-system.service.gov.uk/">GOV.UK Design System</a>. You can <a href="https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/"> migrate to the Design System from GOV.UK Template</a>.</p>

--- a/data/index.yml
+++ b/data/index.yml
@@ -37,8 +37,17 @@ content: >
 
     <div class="notification-summary">
       <h2>GOV.UK Template has now been replaced by the GOV.UK Design System</h2>
-      <p>GOV.UK Template will remain available in case you are currently using it, but is no longer maintained. The Government Digital Service will only carry out major bug fixes and security patches.</p>
-      <p>The <a href="https://www.gov.uk/design-system">GOV.UK Design System</a> will be updated to ensure the things it contains meet level AA of WCAG 2.1, but Elements will not. <a href="https://design-system.service.gov.uk/accessibility/">Read more about accessibility of the GOV.UK Design System</a>.</p>
+
+      <p>GOV.UK Template is:<p>
+
+      <ul>
+      <li>no longer maintained</li>
+      <li>will only be updated for major bug fixes and security patches</li>
+      <li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
+      </ul>
+
+      <p>This framework will remain available in case you’re currently using it. To help your service meet accessibility requirements, you should use the <a href="https://design-system.service.gov.uk/">GOV.UK Design System</a>. You can <a href="https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/"> migrate to the Design System from GOV.UK Template</a>.</p>
+
     </div>
 
     <h2>Examples</h2>

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
       <ul>
       <li>no longer maintained</li>
       <li>will only be updated for major bug fixes and security patches</li>
-      <li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
+      <li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps#meeting-accessibility-requirements">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
       </ul>
 
       <p>This framework will remain available in case you’re currently using it. To help your service meet accessibility requirements, you should use the <a href="https://design-system.service.gov.uk/">GOV.UK Design System</a>. You can <a href="https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/"> migrate to the Design System from GOV.UK Template</a>.</p>

--- a/index.html
+++ b/index.html
@@ -103,8 +103,17 @@
 
     <div class="notification-summary">
       <h2>GOV.UK Template has now been replaced by the GOV.UK Design System</h2>
-      <p>GOV.UK Template will remain available in case you are currently using it, but is no longer maintained. The Government Digital Service will only carry out major bug fixes and security patches.</p>
-      <p>The <a href="https://www.gov.uk/design-system">GOV.UK Design System</a> will be updated to ensure the things it contains meet level AA of WCAG 2.1, but Elements will not. <a href="https://design-system.service.gov.uk/accessibility/">Read more about accessibility of the GOV.UK Design System</a>.</p>
+      
+      <p>GOV.UK Template is:<p>
+
+      <ul>
+      <li>no longer maintained</li>
+      <li>will only be updated for major bug fixes and security patches</li>
+      <li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
+      </ul>
+
+      <p>This framework will remain available in case you’re currently using it. To help your service meet accessibility requirements, you should use the <a href="https://design-system.service.gov.uk/">GOV.UK Design System</a>. You can <a href="https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/"> migrate to the Design System from GOV.UK Template</a>.</p>
+      
     </div>
 
   <h2>Examples</h2>


### PR DESCRIPTION
We’re updating the deprecation notice in the Elements, Template and Frontend Toolkit repos, to reflect the fact that GOV.UK Design System and Frontend have now been updated to better meet WCAG 2.1.