### PR TITLE
Specify content type for GitHub release assets

### DIFF
--- a/build_tools/publisher/release_publisher.rb
+++ b/build_tools/publisher/release_publisher.rb
@@ -15,7 +15,7 @@ module Publisher
       release = @github_client.create_release(GITHUB_REPO, "v#{@version}", name: "Version #{@version}")
       Dir["#{@pkg_dir}/*#{@version}.tgz"].each do |tarball|
         puts "- Uploading #{tarball} to github release"
-        @github_client.upload_asset(release[:url], tarball)
+        @github_client.upload_asset(release[:url], tarball, content_type: 'application/x-gtar')
       end
     end
 


### PR DESCRIPTION
Somewhere between the release of v0.23.0 and v0.23.1, the GitHub Releases publisher has broken.

Since then, when a new release is merged to master, the `build:and_release_if_updated` Rake task fails with:

```
rake aborted!
Octokit::MissingContentType: Please pass content_type or install mime-types gem to guess content type from file
/home/travis/.rvm/gems/ruby-2.4.1/gems/octokit-3.4.2/lib/octokit/client/releases.rb:139:in `rescue in content_type_from_file'
/home/travis/.rvm/gems/ruby-2.4.1/gems/octokit-3.4.2/lib/octokit/client/releases.rb:133:in `content_type_from_file'
/home/travis/.rvm/gems/ruby-2.4.1/gems/octokit-3.4.2/lib/octokit/client/releases.rb:87:in `upload_asset'
/home/travis/build/alphagov/govuk_template/build_tools/publisher/release_publisher.rb:18:in `block in publish'
/home/travis/build/alphagov/govuk_template/build_tools/publisher/release_publisher.rb:16:in `each'
/home/travis/build/alphagov/govuk_template/build_tools/publisher/release_publisher.rb:16:in `publish'
/home/travis/build/alphagov/govuk_template/Rakefile:119:in `block (2 levels) in <top (required)>'
/home/travis/.rvm/gems/ruby-2.4.1/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
Caused by:
LoadError: cannot load such file -- mime/types
/home/travis/.rvm/gems/ruby-2.4.1/gems/octokit-3.4.2/lib/octokit/client/releases.rb:133:in `require'
/home/travis/.rvm/gems/ruby-2.4.1/gems/octokit-3.4.2/lib/octokit/client/releases.rb:133:in `content_type_from_file'
/home/travis/.rvm/gems/ruby-2.4.1/gems/octokit-3.4.2/lib/octokit/client/releases.rb:87:in `upload_asset'
/home/travis/build/alphagov/govuk_template/build_tools/publisher/release_publisher.rb:18:in `block in publish'
/home/travis/build/alphagov/govuk_template/build_tools/publisher/release_publisher.rb:16:in `each'
/home/travis/build/alphagov/govuk_template/build_tools/publisher/release_publisher.rb:16:in `publish'
/home/travis/build/alphagov/govuk_template/Rakefile:119:in `block (2 levels) in <top (required)>'
/home/travis/.rvm/gems/ruby-2.4.1/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => build:and_release_if_updated
(See full trace by running task with --trace)
Done.
Pushing Github release v0.26.0
```

The releases for Play, Mustache, EJS and Jinja would then not be run, as the build would exit, however the next time a master build was triggered these releases would then go out (the GitHub release would be skipped on the next run, as the release now exists on GitHub, albeit without the attached assets)

It's unclear why this changed – in f1b1437 we did bump a number of dependencies, although OctoKit itself remained on 3.4.2. One hypothesis is that one of the dependencies which previously depended on the mine-types gem was updated such that it no longer relied on mime-types.

We could include mime-types, but we know that all of the assets we want to upload will be a gzipped tarball (we're globbing for `#{@pkg_dir}/*#{@version}.tgz`) we can just specify that and it should work.

Probably.