### PR TITLE
Remove reference to asset_bom_removal-rails

### DIFF
--- a/docs/using-with-rails.md
+++ b/docs/using-with-rails.md
@@ -54,5 +54,3 @@ crossorigin="anonymous"></script>`
 The example above is generated automatically by sprockets-rails in your project if the integrity option is set to true:
 
 `<%= stylesheet_script_tag 'example', integrity: true %>`
-
-There is [a bug in Firefox versions less than 52](https://bug623317.bugzilla.mozilla.org/show_bug.cgi?id=1269241) which means it interprets the SRI hash incorrectly for CSS files that start with [the UTF8 byte order mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8).  Sprockets-rails will include a UTF8 BOM in the compiled CSS file if any of the source stylesheets have UTF8 characters in them and this means Firefox < 52 will refuse to load these assets.  To avoid this we developed the [asset_bom_removal-rails](https://github.com/alphagov/asset_bom_removal-rails) gem to strip the UTF8 BOM from compiled CSS assets as part of the rails asset pipeline.


### PR DESCRIPTION
It is [no longer used anywhere](https://github.com/search?q=org%3Aalphagov+asset_bom_removal-rails+-repo%3Aalphagov%2Fasset_bom_removal-rails+-repo%3Aalphagov%2Fgovuk-dependency-analysis&type=code).